### PR TITLE
Add ed25519::Signer::public_key()

### DIFF
--- a/src/ed25519/dalek.rs
+++ b/src/ed25519/dalek.rs
@@ -1,5 +1,6 @@
 use error::{Error, ErrorKind};
 use super::{Signature, Signer};
+use super::PublicKey as SignatoryPublicKey;
 
 use ed25519_dalek::{Keypair, PublicKey, SecretKey};
 use sha2::Sha512;
@@ -21,6 +22,10 @@ impl DalekSigner {
 }
 
 impl Signer for DalekSigner {
+    fn public_key(&mut self) -> Result<SignatoryPublicKey, Error> {
+        Ok(SignatoryPublicKey(self.0.public.to_bytes()))
+    }
+
     fn sign(&mut self, msg: &[u8]) -> Result<Signature, Error> {
         Ok(Signature(self.0.sign::<Sha512>(msg).to_bytes()))
     }

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -118,6 +118,9 @@ impl fmt::Debug for Signature {
 /// Parent trait for Ed25519 signers
 /// Signer is an object-safe trait for producing a particular type of signature
 pub trait Signer {
+    /// Obtain the public key which identifies this signer
+    fn public_key(&mut self) -> Result<PublicKey, Error>;
+
     /// Compute an Ed25519 signature for the given message
     fn sign(&mut self, msg: &[u8]) -> Result<Signature, Error>;
 }


### PR DESCRIPTION
All providers should know the public key which corresponds to their secret key. This is useful for checking the signer is correctly configured.