### PR TITLE
Add more bounds to the Verifier trait

### DIFF
--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -1,5 +1,6 @@
 //! Ed25519 public keys
 
+use core::fmt;
 use core::marker::PhantomData;
 
 use error::{Error, ErrorKind};
@@ -9,7 +10,7 @@ use super::{DefaultVerifier, Signature, Verifier};
 pub const PUBLIC_KEY_SIZE: usize = 32;
 
 /// Ed25519 public keys
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct PublicKey<V = DefaultVerifier>
 where
     V: Verifier,
@@ -54,9 +55,25 @@ impl<V: Verifier> PublicKey<V> {
     }
 }
 
-impl AsRef<[u8]> for PublicKey {
+impl<V: Verifier> AsRef<[u8]> for PublicKey<V> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.bytes.as_ref()
+    }
+}
+
+impl<V: Verifier> fmt::Debug for PublicKey<V> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "signatory::ed25519::PublicKey(")?;
+
+        for (i, byte) in self.bytes.iter().enumerate() {
+            write!(f, "{:02x}", byte)?;
+
+            if i != self.bytes.len() - 1 {
+                write!(f, ":")?;
+            }
+        }
+
+        write!(f, ")")
     }
 }

--- a/src/ed25519/verifier.rs
+++ b/src/ed25519/verifier.rs
@@ -2,6 +2,9 @@
 //!
 //! This is intended to be used in conjunction with the `verify` method of `PublicKey`
 
+use core::fmt::Debug;
+use core::hash::Hash;
+
 #[cfg(feature = "dalek-provider")]
 pub use providers::dalek::Ed25519Verifier as DefaultVerifier;
 
@@ -16,7 +19,7 @@ use error::Error;
 use super::{PublicKey, Signature};
 
 /// Verifier for Ed25519 signatures
-pub trait Verifier: Clone + Sync + Sized {
+pub trait Verifier: Clone + Debug + Hash + Eq + PartialEq + Sync + Sized {
     /// Verify an Ed25519 signature against the given public key
     fn verify(key: &PublicKey<Self>, msg: &[u8], signature: &Signature) -> Result<(), Error>;
 }
@@ -24,7 +27,7 @@ pub trait Verifier: Clone + Sync + Sized {
 /// A panicking default verifier if no providers have been selected
 #[cfg(all(not(feature = "dalek-provider"), not(feature = "ring-provider"),
           not(feature = "sodiumoxide-provider")))]
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct DefaultVerifier {}
 
 #[cfg(all(not(feature = "dalek-provider"), not(feature = "ring-provider"),

--- a/src/providers/dalek/ed25519.rs
+++ b/src/providers/dalek/ed25519.rs
@@ -35,7 +35,7 @@ impl Signer for Ed25519Signer {
 }
 
 /// Ed25519 verifier provider for ed25519-dalek
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Ed25519Verifier {}
 
 impl Verifier for Ed25519Verifier {

--- a/src/providers/ring/ed25519.rs
+++ b/src/providers/ring/ed25519.rs
@@ -34,7 +34,7 @@ impl Signer for Ed25519Signer {
 }
 
 /// Ed25519 verifier provider for *ring*
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Ed25519Verifier {}
 
 impl Verifier for Ed25519Verifier {

--- a/src/providers/sodiumoxide/ed25519.rs
+++ b/src/providers/sodiumoxide/ed25519.rs
@@ -41,7 +41,7 @@ impl Signer for Ed25519Signer {
 }
 
 /// Ed25519 verifier provider for *sodiumoxide*
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Ed25519Verifier {}
 
 impl Verifier for Ed25519Verifier {


### PR DESCRIPTION
Requires verifiers (which are merely tuple structs) implement all of the same traits as PublicKey derives, since we need them to even though they're only used as PhantomData.