### PR TITLE
.circleci/config.yml: Test sodiumoxide-provider in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
       # NOTE: RUST_NIGHTLY_VERSION is set in the Dockerfile
       - RUSTFLAGS: -C target-feature=+aes
-      - CARGO_FEATURES: dalek-provider,ring-provider,yubihsm-mockhsm
+      - CARGO_FEATURES: dalek-provider,sodiumoxide-provider,ring-provider,yubihsm-mockhsm
 
     steps:
       - checkout

--- a/src/providers/sodiumoxide/ed25519.rs
+++ b/src/providers/sodiumoxide/ed25519.rs
@@ -31,7 +31,7 @@ impl Ed25519Signer {
 
 impl Signer for Ed25519Signer {
     fn public_key(&self) -> Result<PublicKey, Error> {
-        Ok(self.public_key.clone())
+        Ok(self.public_key)
     }
 
     fn sign(&self, msg: &[u8]) -> Result<Signature, Error> {


### PR DESCRIPTION
The Docker image now has libsodium