### PR TITLE
Ed25519 FromSeed trait and miscellaneous cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ yubihsm = { version = "0.7", optional = true }
 criterion = "0.2"
 
 [features]
-dalek-provider = ["ed25519-dalek", "sha2", "verifier"]
+dalek-provider = ["ed25519", "ed25519-dalek", "sha2"]
 default = ["dalek-provider"]
+ed25519 = []
 nightly = ["ed25519-dalek/nightly"]
 std = []
-ring-provider = ["ring", "untrusted", "verifier"]
-sodiumoxide-provider = ["sodiumoxide", "verifier"]
-verifier = []
-yubihsm-provider = ["std", "yubihsm"]
+ring-provider = ["ed25519", "ring", "untrusted"]
+sodiumoxide-provider = ["ed25519", "sodiumoxide"]
+yubihsm-provider = ["ed25519", "std", "yubihsm"]
 yubihsm-mockhsm = ["yubihsm-provider", "yubihsm/mockhsm"]
 
 [package.metadata.docs.rs]

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -7,6 +7,10 @@ mod signature;
 mod signer;
 mod verifier;
 
+#[cfg(test)]
+#[macro_use]
+mod test_macros;
+
 /// RFC 8032 Ed25519 test vectors
 mod test_vectors;
 
@@ -15,6 +19,6 @@ pub const SEED_SIZE: usize = 32;
 
 pub use self::public_key::{PublicKey, PUBLIC_KEY_SIZE};
 pub use self::signature::{Signature, SIGNATURE_SIZE};
-pub use self::signer::Signer;
+pub use self::signer::{FromSeed, Signer};
 pub use self::verifier::{DefaultVerifier, Verifier};
 pub use self::test_vectors::TEST_VECTORS;

--- a/src/ed25519/signer.rs
+++ b/src/ed25519/signer.rs
@@ -3,6 +3,16 @@
 use error::Error;
 use super::{PublicKey, Signature};
 
+/// Trait for Ed25519 signers that can be initialized from a seed value
+pub trait FromSeed: Sized {
+    /// Create a new Ed25519 signer from a seed (i.e. unexpanded private key)
+    ///
+    /// Seed values are 32-bytes of uniformly random data. This is in contrast
+    /// to an Ed25519 keypair, which is 64-bytes and includes both the seed
+    /// value and the public key.
+    fn from_seed(seed: &[u8]) -> Result<Self, Error>;
+}
+
 /// Trait for Ed25519 signers (object-safe)
 pub trait Signer: Sync {
     /// Obtain the public key which identifies this signer

--- a/src/ed25519/test_macros.rs
+++ b/src/ed25519/test_macros.rs
@@ -1,0 +1,55 @@
+//! Macro for generating shared tests for all software Ed25519 implementations
+
+macro_rules! ed25519_tests {
+    ($signer: ident, $verifier: ident) => {
+        use std::vec::Vec;
+        use error::ErrorKind;
+        use ed25519::{FromSeed, PublicKey, Signature, Signer, Verifier, TEST_VECTORS};
+
+        #[test]
+        fn sign_rfc8032_test_vectors() {
+            for vector in TEST_VECTORS {
+                let mut signer = $signer::from_seed(vector.sk).expect("decode error");
+                assert_eq!(signer.sign(vector.msg).unwrap().as_ref(), vector.sig);
+            }
+        }
+
+        #[test]
+        fn verify_rfc8032_test_vectors() {
+            for vector in TEST_VECTORS {
+                let pk = PublicKey::from_bytes(vector.pk).unwrap();
+                let sig = Signature::from_bytes(vector.sig).unwrap();
+                assert!(
+                    $verifier::verify(&pk, vector.msg, &sig).is_ok(),
+                    "expected signature to verify"
+                );
+            }
+        }
+
+        #[test]
+        fn rejects_tweaked_rfc8032_test_vectors() {
+            for vector in TEST_VECTORS {
+                let pk = PublicKey::from_bytes(vector.pk).unwrap();
+
+                let mut tweaked_sig = Vec::from(vector.sig);
+                tweaked_sig[0] ^= 0x42;
+
+                let result = $verifier::verify(
+                    &pk,
+                    vector.msg,
+                    &Signature::from_bytes(&tweaked_sig).unwrap(),
+                );
+
+                assert!(
+                    result.is_err(),
+                    "expected signature verification failure but it succeeded"
+                );
+
+                match result.err().unwrap().kind() {
+                    ErrorKind::SignatureInvalid => (),
+                    other => panic!("expected ErrorKind::SignatureInvalid, got {:?}", other),
+                }
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ extern crate std;
 extern crate ed25519_dalek;
 #[cfg(feature = "ring-provider")]
 extern crate ring;
-#[cfg(feature = "dalek-provider")]
+#[cfg(feature = "sha2")]
 extern crate sha2;
 #[cfg(feature = "sodiumoxide-provider")]
 extern crate sodiumoxide;
@@ -49,9 +49,12 @@ extern crate yubihsm;
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "ed25519")]
+#[macro_use]
 pub mod ed25519;
 pub mod error;
 pub mod providers;
 pub mod test_vector;
+mod util;
 
 pub use error::Error;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 //! Signatory macros (for error handling)
 
-#[allow(unused_macros)]
+#![allow(unused_macros)]
 
 /// Create a new error (of a given enum variant) with a formatted message
 #[cfg(not(feature = "std"))]
@@ -27,5 +27,19 @@ macro_rules! err {
             ::error::ErrorKind::$variant,
             Some(&format!($fmt, $($arg)+))
         )
+    };
+}
+
+/// Assert a condition is true, returning an error type with a formatted message if not
+macro_rules! ensure {
+    ($condition: expr, $variant:ident, $msg:expr) => {
+        if !($condition) {
+            return Err(err!($variant, $msg).into());
+        }
+    };
+    ($condition: expr, $variant:ident, $fmt:expr, $($arg:tt)+) => {
+        if !($condition) {
+            return Err(err!($variant, $fmt, $($arg)+).into());
+        }
     };
 }

--- a/src/providers/dalek/ed25519.rs
+++ b/src/providers/dalek/ed25519.rs
@@ -6,14 +6,14 @@ use ed25519_dalek::Signature as DalekSignature;
 use sha2::Sha512;
 
 use error::{Error, ErrorKind};
-use ed25519::{PublicKey, Signature, Signer, Verifier};
+use ed25519::{FromSeed, PublicKey, Signature, Signer, Verifier};
 
 /// Ed25519 signature provider for ed25519-dalek
 pub struct Ed25519Signer(Keypair);
 
-impl Ed25519Signer {
+impl FromSeed for Ed25519Signer {
     /// Create a new DalekSigner from an unexpanded seed value
-    pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
+    fn from_seed(seed: &[u8]) -> Result<Self, Error> {
         let sk = SecretKey::from_bytes(seed).or(Err(ErrorKind::KeyInvalid))?;
         let pk = DalekPublicKey::from_secret::<Sha512>(&sk);
 
@@ -55,55 +55,6 @@ impl Verifier for Ed25519Verifier {
 
 #[cfg(test)]
 mod tests {
-    use std::vec::Vec;
-
-    use error::ErrorKind;
-    use ed25519::{PublicKey, Signature, Signer, Verifier, TEST_VECTORS};
     use super::{Ed25519Signer, Ed25519Verifier};
-
-    #[test]
-    fn sign_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let mut signer = Ed25519Signer::from_seed(vector.sk).expect("decode error");
-            assert_eq!(signer.sign(vector.msg).unwrap().as_ref(), vector.sig);
-        }
-    }
-
-    #[test]
-    fn verify_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let pk = PublicKey::from_bytes(vector.pk).unwrap();
-            let sig = Signature::from_bytes(vector.sig).unwrap();
-            assert!(
-                Ed25519Verifier::verify(&pk, vector.msg, &sig).is_ok(),
-                "expected signature to verify"
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_tweaked_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let pk = PublicKey::from_bytes(vector.pk).unwrap();
-
-            let mut tweaked_sig = Vec::from(vector.sig);
-            tweaked_sig[0] ^= 0x42;
-
-            let result = Ed25519Verifier::verify(
-                &pk,
-                vector.msg,
-                &Signature::from_bytes(&tweaked_sig).unwrap(),
-            );
-
-            assert!(
-                result.is_err(),
-                "expected signature verification failure but it succeeded"
-            );
-
-            match result.err().unwrap().kind() {
-                ErrorKind::SignatureInvalid => (),
-                other => panic!("expected ErrorKind::SignatureInvalid, got {:?}", other),
-            }
-        }
-    }
+    ed25519_tests!(Ed25519Signer, Ed25519Verifier);
 }

--- a/src/providers/ring/ed25519.rs
+++ b/src/providers/ring/ed25519.rs
@@ -1,25 +1,38 @@
-//! Digital signature (i.e. Ed25519) provider for *ring*
+//! Ed25519 signer and verifier implementation for *ring*
 
 use ring;
 use ring::signature::Ed25519KeyPair;
 use untrusted;
 
 use error::{Error, ErrorKind};
-use ed25519::{PublicKey, Signature, Signer, Verifier, SEED_SIZE};
+use ed25519::{FromSeed, PublicKey, Signature, Signer, Verifier, SEED_SIZE};
 
 /// Ed25519 signature provider for *ring*
 pub struct Ed25519Signer(Ed25519KeyPair);
 
-impl Ed25519Signer {
-    /// Create a new RingSigner from an unexpanded seed value
-    pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
-        if seed.len() != SEED_SIZE {
-            return Err(ErrorKind::KeyInvalid.into());
-        }
+impl FromSeed for Ed25519Signer {
+    /// Create a new Ed25519Signer from an unexpanded seed value
+    fn from_seed(seed: &[u8]) -> Result<Self, Error> {
+        ensure!(
+            seed.len() == SEED_SIZE,
+            KeyInvalid,
+            "expected {}-byte seed (got {})",
+            SEED_SIZE,
+            seed.len()
+        );
 
-        Ok(Ed25519Signer(
-            Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(seed)).unwrap(),
-        ))
+        let keypair = Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(seed)).unwrap();
+        Ok(Ed25519Signer(keypair))
+    }
+}
+
+impl Ed25519Signer {
+    /// Create a new Ed25519Signer from a PKCS#8 encoded private key
+    pub fn from_pkcs8(bytes: &[u8]) -> Result<Self, Error> {
+        let keypair = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(bytes))
+            .map_err(|_| err!(KeyInvalid, "invalid PKCS#8 private key"))?;
+
+        Ok(Ed25519Signer(keypair))
     }
 }
 
@@ -50,55 +63,6 @@ impl Verifier for Ed25519Verifier {
 
 #[cfg(test)]
 mod tests {
-    use std::vec::Vec;
-
-    use error::ErrorKind;
-    use ed25519::{PublicKey, Signature, Signer, Verifier, TEST_VECTORS};
     use super::{Ed25519Signer, Ed25519Verifier};
-
-    #[test]
-    fn sign_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let mut signer = Ed25519Signer::from_seed(vector.sk).expect("decode error");
-            assert_eq!(signer.sign(vector.msg).unwrap().as_ref(), vector.sig);
-        }
-    }
-
-    #[test]
-    fn verify_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let pk = PublicKey::from_bytes(vector.pk).unwrap();
-            let sig = Signature::from_bytes(vector.sig).unwrap();
-            assert!(
-                Ed25519Verifier::verify(&pk, vector.msg, &sig).is_ok(),
-                "expected signature to verify"
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_tweaked_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let pk = PublicKey::from_bytes(vector.pk).unwrap();
-
-            let mut tweaked_sig = Vec::from(vector.sig);
-            tweaked_sig[0] ^= 0x42;
-
-            let result = Ed25519Verifier::verify(
-                &pk,
-                vector.msg,
-                &Signature::from_bytes(&tweaked_sig).unwrap(),
-            );
-
-            assert!(
-                result.is_err(),
-                "expected signature verification failure but it succeeded"
-            );
-
-            match result.err().unwrap().kind() {
-                ErrorKind::SignatureInvalid => (),
-                other => panic!("expected ErrorKind::SignatureInvalid, got {:?}", other),
-            }
-        }
-    }
+    ed25519_tests!(Ed25519Signer, Ed25519Verifier);
 }

--- a/src/providers/sodiumoxide/ed25519.rs
+++ b/src/providers/sodiumoxide/ed25519.rs
@@ -4,7 +4,7 @@ use sodiumoxide::crypto::sign::ed25519 as sodiumoxide_ed25519;
 use sodiumoxide::crypto::sign::ed25519::{SecretKey, Seed};
 
 use error::{Error, ErrorKind};
-use ed25519::{PublicKey, Signature, Signer, Verifier, SEED_SIZE};
+use ed25519::{FromSeed, PublicKey, Signature, Signer, Verifier, SEED_SIZE};
 
 /// Ed25519 signature provider for *ring*
 pub struct Ed25519Signer {
@@ -12,12 +12,16 @@ pub struct Ed25519Signer {
     public_key: PublicKey,
 }
 
-impl Ed25519Signer {
+impl FromSeed for Ed25519Signer {
     /// Create a new SodiumOxideSigner from an unexpanded seed value
-    pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
-        if seed.len() != SEED_SIZE {
-            return Err(ErrorKind::KeyInvalid.into());
-        }
+    fn from_seed(seed: &[u8]) -> Result<Self, Error> {
+        ensure!(
+            seed.len() == SEED_SIZE,
+            KeyInvalid,
+            "expected {}-byte seed (got {})",
+            SEED_SIZE,
+            seed.len()
+        );
 
         let (public_key, secret_key) =
             sodiumoxide_ed25519::keypair_from_seed(&Seed::from_slice(seed).unwrap());
@@ -36,7 +40,7 @@ impl Signer for Ed25519Signer {
 
     fn sign(&self, msg: &[u8]) -> Result<Signature, Error> {
         let signature = sodiumoxide_ed25519::sign_detached(msg, &self.secret_key);
-        Ok(Signature::from_bytes(&signature.0).unwrap())
+        Ok(Signature::from_bytes(&signature.0[..]).unwrap())
     }
 }
 
@@ -59,55 +63,6 @@ impl Verifier for Ed25519Verifier {
 
 #[cfg(test)]
 mod tests {
-    use std::vec::Vec;
-
-    use error::ErrorKind;
-    use ed25519::{PublicKey, Signature, Signer, Verifier, TEST_VECTORS};
     use super::{Ed25519Signer, Ed25519Verifier};
-
-    #[test]
-    fn sign_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let mut signer = Ed25519Signer::from_seed(vector.sk).expect("decode error");
-            assert_eq!(signer.sign(vector.msg).unwrap().as_ref(), vector.sig);
-        }
-    }
-
-    #[test]
-    fn verify_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let pk = PublicKey::from_bytes(vector.pk).unwrap();
-            let sig = Signature::from_bytes(vector.sig).unwrap();
-            assert!(
-                Ed25519Verifier::verify(&pk, vector.msg, &sig).is_ok(),
-                "expected signature to verify"
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_tweaked_rfc8032_test_vectors() {
-        for vector in TEST_VECTORS {
-            let pk = PublicKey::from_bytes(vector.pk).unwrap();
-
-            let mut tweaked_sig = Vec::from(vector.sig);
-            tweaked_sig[0] ^= 0x42;
-
-            let result = Ed25519Verifier::verify(
-                &pk,
-                vector.msg,
-                &Signature::from_bytes(&tweaked_sig).unwrap(),
-            );
-
-            assert!(
-                result.is_err(),
-                "expected signature verification failure but it succeeded"
-            );
-
-            match result.err().unwrap().kind() {
-                ErrorKind::SignatureInvalid => (),
-                other => panic!("expected ErrorKind::SignatureInvalid, got {:?}", other),
-            }
-        }
-    }
+    ed25519_tests!(Ed25519Signer, Ed25519Verifier);
 }

--- a/src/providers/yubihsm/ed25519.rs
+++ b/src/providers/yubihsm/ed25519.rs
@@ -50,7 +50,7 @@ impl<C: Connector> Signer for Ed25519Signer<C> {
             return Err(ErrorKind::KeyInvalid.into());
         }
 
-        Ok(PublicKey::from_bytes(pubkey_response.data.as_ref()).unwrap())
+        Ok(PublicKey::from_bytes(&pubkey_response.data).unwrap())
     }
 
     fn sign(&self, msg: &[u8]) -> Result<Signature, Error> {
@@ -60,7 +60,7 @@ impl<C: Connector> Signer for Ed25519Signer<C> {
             .sign_data_eddsa(self.signing_key_id, msg)
             .map_err(|e| err!(ProviderError, "{}", e))?;
 
-        Ok(Signature::from_bytes(response.signature.as_ref()).unwrap())
+        Ok(Signature::from_bytes(&response.signature).unwrap())
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,21 @@
+//! Miscellaneous utility functions
+
+use core::fmt;
+
+#[allow(dead_code)]
+pub(crate) fn fmt_colon_delimited_hex<B>(f: &mut fmt::Formatter, bytes: B) -> fmt::Result
+where
+    B: AsRef<[u8]>,
+{
+    let len = bytes.as_ref().len();
+
+    for (i, byte) in bytes.as_ref().iter().enumerate() {
+        write!(f, "{:02x}", byte)?;
+
+        if i != len - 1 {
+            write!(f, ":")?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a FromSeed trait that all software implementations of Ed25519 can implement, allowing them to be used interchangably.

Also includes a few miscellaneous code cleanups, including using a macro to generate shared Ed25519 tests.