### PR TITLE
ECDSA verification support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ circle-ci = { repository = "tendermint/signatory" }
 [dependencies]
 ed25519-dalek = { version = "0.6", optional = true, default-features = false, features = ["sha2"] }
 generic-array = { version = "0.9", optional = true }
+lazy_static = { version = "1", optional = true }
 ring = { version = "0.12", optional = true }
 secp256k1 = { version = "0.9", optional = true }
 sha2 = { version = "0.7", optional = true }
@@ -34,7 +35,7 @@ ed25519 = []
 nightly = ["ed25519-dalek/nightly"]
 std = []
 ring-provider = ["ed25519", "ring", "untrusted"]
-secp256k1-provider = ["ecdsa", "secp256k1", "sha2", "std"]
+secp256k1-provider = ["ecdsa", "lazy_static", "secp256k1", "sha2", "std"]
 sodiumoxide-provider = ["ed25519", "sodiumoxide"]
 yubihsm-provider = ["ed25519", "std", "yubihsm"]
 yubihsm-mockhsm = ["yubihsm-provider", "yubihsm/mockhsm"]

--- a/src/ecdsa/curve/mod.rs
+++ b/src/ecdsa/curve/mod.rs
@@ -7,6 +7,7 @@ use core::hash::Hash;
 use generic_array::ArrayLength;
 
 pub use self::secp256k1::Secp256k1;
+use super::verifier::Verifier;
 
 /// Elliptic curve in short Weierstrass form suitable for use with ECDSA
 pub trait WeierstrassCurve: Clone + Debug + Default + Hash + Eq + PartialEq + Sync + Sized {
@@ -18,4 +19,7 @@ pub trait WeierstrassCurve: Clone + Debug + Default + Hash + Eq + PartialEq + Sy
 
     /// Size of a compact, fixed-sized signature for this curve
     type RawSignatureSize: ArrayLength<u8>;
+
+    /// Default ECDSA verification provider to use for this curve
+    type DefaultSignatureVerifier: Verifier<Self>;
 }

--- a/src/ecdsa/curve/secp256k1/mod.rs
+++ b/src/ecdsa/curve/secp256k1/mod.rs
@@ -12,7 +12,9 @@ use ecdsa::RawSignature as GenericRawSignature;
 use ecdsa::DERSignature as GenericDERSignature;
 use super::WeierstrassCurve;
 
-pub use self::test_vectors::TEST_VECTORS;
+// TODO: mark these as pub when we have a well-vetted set of test vectors
+#[allow(unused_imports)]
+pub(crate) use self::test_vectors::RAW_TEST_VECTORS;
 
 /// The secp256k1 elliptic curve: y² = x³ + 7 over a ~256-bit field
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
@@ -22,6 +24,12 @@ impl WeierstrassCurve for Secp256k1 {
     type PrivateKeySize = U32;
     type PublicKeySize = U33;
     type RawSignatureSize = U64;
+
+    #[cfg(feature = "secp256k1-provider")]
+    type DefaultSignatureVerifier = ::providers::secp256k1::ECDSAVerifier;
+
+    #[cfg(not(feature = "secp256k1-provider"))]
+    type DefaultSignatureVerifier = ::ecdsa::verifier::PanickingVerifier<Self>;
 }
 
 /// secp256k1 public key

--- a/src/ecdsa/curve/secp256k1/test_vectors.rs
+++ b/src/ecdsa/curve/secp256k1/test_vectors.rs
@@ -12,9 +12,11 @@
 
 use test_vector::TestVector;
 
-/// secp256k1 ECDSA test vectors (from the Python Cryptography library)
-pub const TEST_VECTORS: &[TestVector] = &[
-    // TODO: actually test against these vectors!
+/// secp256k1 raw ECDSA test vectors (from the Python Cryptography library)
+// TODO: mark these as pub when we have a well-vetted set of test vectors
+#[allow(dead_code)]
+pub(crate) const RAW_TEST_VECTORS: &[TestVector] = &[
+    // TODO: verify the conversions of these vectors from the upstream ones are correct and actually test against them
     TestVector {
         sk: b"\x13\x1c\xa4\xe5\x81\x12\x67\xfa\x90\xfc\x63\x1d\x62\x98\xc2\xd7\xa4\xec\xcc\xc4\x5c\xc6\x0d\x37\x8e\x06\x60\xb6\x1f\x82\xfe\x8d",
         pk: b"\xcf\x5a\xcf\x8e\xd3\xe0\xbb\xf7\x35\x30\x8c\xc4\x15\x60\x4b\xd3\x4a\xb8\xf7\xfc\x8b\x4a\x22\x74\x11\x17\xa7\xfb\xc7\x2a\x79\x49",

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -5,6 +5,7 @@ pub mod curve;
 mod public_key;
 mod signature;
 mod signer;
+mod verifier;
 
 pub use self::curve::Secp256k1;
 pub use self::public_key::PublicKey;
@@ -12,3 +13,4 @@ pub use self::public_key::PublicKey;
 pub use self::signature::DERSignature;
 pub use self::signature::RawSignature;
 pub use self::signer::{FixedSizeInputSigner, Signer};
+pub use self::verifier::{FixedSizeInputVerifier, Verifier};

--- a/src/ecdsa/public_key.rs
+++ b/src/ecdsa/public_key.rs
@@ -6,6 +6,9 @@ use generic_array::GenericArray;
 use generic_array::typenum::Unsigned;
 
 use error::Error;
+#[cfg(feature = "std")]
+use super::DERSignature;
+use super::{RawSignature, Verifier};
 use super::curve::WeierstrassCurve;
 use util::fmt_colon_delimited_hex;
 
@@ -49,6 +52,27 @@ impl<C: WeierstrassCurve> PublicKey<C> {
     #[inline]
     pub fn into_bytes(self) -> GenericArray<u8, C::PublicKeySize> {
         self.bytes
+    }
+
+    /// Verify a fixed-sized (a.k.a. "compact") ECDSA signature
+    #[inline]
+    pub fn verify_sha2_raw_signature(
+        &self,
+        msg: &[u8],
+        signature: &RawSignature<C>,
+    ) -> Result<(), Error> {
+        C::DefaultSignatureVerifier::verify_sha2_raw_signature(self, msg, signature)
+    }
+
+    /// Verify an ASN.1 DER-encoded ECDSA signature
+    #[cfg(feature = "std")]
+    #[inline]
+    pub fn verify_sha2_der_signature(
+        &self,
+        msg: &[u8],
+        signature: &DERSignature<C>,
+    ) -> Result<(), Error> {
+        C::DefaultSignatureVerifier::verify_sha2_der_signature(self, msg, signature)
     }
 }
 

--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -8,7 +8,8 @@ use super::DERSignature;
 use super::{PublicKey, RawSignature};
 use super::curve::WeierstrassCurve;
 
-/// Sign a message the same size as the curve's field
+/// Sign a raw message the same size as the curve's field (i.e. without first
+/// computing a SHA-2 digest of the message)
 pub trait FixedSizeInputSigner<C: WeierstrassCurve>: Sync {
     /// Compute a compact, fixed-width signature of a fixed-sized message
     /// whose length matches the size of the curve's field.
@@ -31,7 +32,7 @@ pub trait FixedSizeInputSigner<C: WeierstrassCurve>: Sync {
 /// When using this trait, the message will first be hashed using the SHA-2
 /// function whose digest size matches the size of the elliptic curve's field.
 ///
-/// Support is not (yet) provided for mixing and matching curve and
+/// NOTE: Support is not (yet) provided for mixing and matching curve and
 /// digest sizes. If you are interested in this, please open an issue.
 pub trait Signer<C: WeierstrassCurve>: Sync {
     /// Obtain the public key which identifies this signer

--- a/src/ecdsa/verifier.rs
+++ b/src/ecdsa/verifier.rs
@@ -1,0 +1,86 @@
+//! Trait for ECDSA verifiers
+
+use core::fmt::Debug;
+use core::hash::Hash;
+use core::marker::PhantomData;
+use generic_array::GenericArray;
+
+use error::Error;
+#[cfg(feature = "std")]
+use super::DERSignature;
+use super::{PublicKey, RawSignature};
+use super::curve::WeierstrassCurve;
+
+/// Verify a raw message the same size as the curve's field (i.e. without first
+/// computing a SHA-2 digest of the message)
+pub trait FixedSizeInputVerifier<C: WeierstrassCurve>: Verifier<C> + Sync {
+    /// Verify a compact, fixed-width signature of a fixed-sized message
+    /// whose length matches the size of the curve's field.
+    fn verify_fixed_raw_signature(
+        key: &PublicKey<C>,
+        msg: &GenericArray<u8, C::PrivateKeySize>,
+        signature: &RawSignature<C>,
+    ) -> Result<(), Error>;
+
+    /// Verify an ASN.1 DER encoded signature of a fixed-sized message
+    /// whose length matches the size of the curve's field.
+    #[cfg(feature = "std")]
+    fn verify_fixed_der_signature(
+        key: &PublicKey<C>,
+        msg: &GenericArray<u8, C::PrivateKeySize>,
+        signature: &DERSignature<C>,
+    ) -> Result<(), Error>;
+}
+
+/// Verifier for ECDSA signatures which first hashes the input message using
+/// the SHA-2 function whose digest matches the size of the elliptic curve's
+/// field.
+///
+/// NOTE: Support is not (yet) provided for mixing and matching curve and
+/// digest sizes. If you are interested in this, please open an issue.
+pub trait Verifier<C>: Clone + Debug + Hash + Eq + PartialEq + Sync + Sized
+where
+    C: WeierstrassCurve,
+{
+    /// Verify a fixed-sized (a.k.a. "compact") ECDSA signature against the given public key
+    fn verify_sha2_raw_signature(
+        key: &PublicKey<C>,
+        msg: &[u8],
+        signature: &RawSignature<C>,
+    ) -> Result<(), Error>;
+
+    /// Verify an ASN.1 DER-encoded ECDSA signature against the given public key
+    #[cfg(feature = "std")]
+    fn verify_sha2_der_signature(
+        key: &PublicKey<C>,
+        msg: &[u8],
+        signature: &DERSignature<C>,
+    ) -> Result<(), Error>;
+}
+
+/// A panicking verifier we can use as the default if no other verifiers are available
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct PanickingVerifier<C: WeierstrassCurve> {
+    c: PhantomData<C>,
+}
+
+#[allow(dead_code)]
+impl<C: WeierstrassCurve> Verifier<C> for PanickingVerifier<C> {
+    fn verify_sha2_raw_signature(
+        _key: &PublicKey<C>,
+        _msg: &[u8],
+        _signature: &RawSignature<C>,
+    ) -> Result<(), Error> {
+        panic!("no default provider available for {:?} ECDSA", C::default());
+    }
+
+    #[cfg(feature = "std")]
+    fn verify_sha2_der_signature(
+        _key: &PublicKey<C>,
+        _msg: &[u8],
+        _signature: &DERSignature<C>,
+    ) -> Result<(), Error> {
+        panic!("no default provider available for {:?} ECDSA", C::default());
+    }
+}

--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -1,7 +1,6 @@
 //! Ed25519 public keys
 
 use core::fmt;
-use core::marker::PhantomData;
 
 use error::Error;
 use super::{DefaultVerifier, Signature, Verifier};
@@ -12,18 +11,9 @@ pub const PUBLIC_KEY_SIZE: usize = 32;
 
 /// Ed25519 public keys
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct PublicKey<V = DefaultVerifier>
-where
-    V: Verifier,
-{
-    /// Compressed Edwards-y coordinate representing an Ed25519 public key
-    pub bytes: [u8; PUBLIC_KEY_SIZE],
+pub struct PublicKey(pub [u8; PUBLIC_KEY_SIZE]);
 
-    /// Placeholder for verification provider
-    verifier: PhantomData<V>,
-}
-
-impl<V: Verifier> PublicKey<V> {
+impl PublicKey {
     /// Create an Ed25519 public key from its serialized (compressed Edwards-y) form
     pub fn from_bytes<B>(bytes: B) -> Result<Self, Error>
     where
@@ -39,38 +29,35 @@ impl<V: Verifier> PublicKey<V> {
 
         let mut public_key = [0u8; PUBLIC_KEY_SIZE];
         public_key.copy_from_slice(bytes.as_ref());
-        Ok(Self {
-            bytes: public_key,
-            verifier: PhantomData,
-        })
+        Ok(PublicKey(public_key))
     }
 
     /// Obtain public key as a byte array reference
     #[inline]
     pub fn as_bytes(&self) -> &[u8; PUBLIC_KEY_SIZE] {
-        &self.bytes
+        &self.0
     }
 
     /// Convert public key into owned byte array
     #[inline]
     pub fn into_bytes(self) -> [u8; PUBLIC_KEY_SIZE] {
-        self.bytes
+        self.0
     }
 
     /// Verify a signature using this key
     pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
-        V::verify(self, msg, signature)
+        DefaultVerifier::verify(self, msg, signature)
     }
 }
 
-impl<V: Verifier> AsRef<[u8]> for PublicKey<V> {
+impl AsRef<[u8]> for PublicKey {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        self.bytes.as_ref()
+        self.0.as_ref()
     }
 }
 
-impl<V: Verifier> fmt::Debug for PublicKey<V> {
+impl fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "signatory::ed25519::PublicKey(")?;
         fmt_colon_delimited_hex(f, self.as_ref())?;

--- a/src/ed25519/verifier.rs
+++ b/src/ed25519/verifier.rs
@@ -21,7 +21,7 @@ use super::{PublicKey, Signature};
 /// Verifier for Ed25519 signatures
 pub trait Verifier: Clone + Debug + Hash + Eq + PartialEq + Sync + Sized {
     /// Verify an Ed25519 signature against the given public key
-    fn verify(key: &PublicKey<Self>, msg: &[u8], signature: &Signature) -> Result<(), Error>;
+    fn verify(key: &PublicKey, msg: &[u8], signature: &Signature) -> Result<(), Error>;
 }
 
 /// A panicking default verifier if no providers have been selected

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ extern crate std;
 extern crate ed25519_dalek;
 #[cfg(feature = "ecdsa")]
 pub extern crate generic_array;
+#[cfg(feature = "secp256k1-provider")]
+#[macro_use]
+extern crate lazy_static;
 #[cfg(feature = "ring-provider")]
 extern crate ring;
 #[cfg(feature = "secp256k1-provider")]

--- a/src/providers/dalek/ed25519.rs
+++ b/src/providers/dalek/ed25519.rs
@@ -39,13 +39,11 @@ impl Signer for Ed25519Signer {
 pub struct Ed25519Verifier {}
 
 impl Verifier for Ed25519Verifier {
-    fn verify(key: &PublicKey<Self>, msg: &[u8], signature: &Signature) -> Result<(), Error> {
+    fn verify(key: &PublicKey, msg: &[u8], signature: &Signature) -> Result<(), Error> {
+        let pk = DalekPublicKey::from_bytes(key.as_ref()).unwrap();
         let sig = DalekSignature::from_bytes(signature.as_ref()).unwrap();
 
-        if DalekPublicKey::from_bytes(&key.bytes)
-            .unwrap()
-            .verify::<Sha512>(msg, &sig)
-        {
+        if pk.verify::<Sha512>(msg, &sig) {
             Ok(())
         } else {
             Err(ErrorKind::SignatureInvalid.into())

--- a/src/providers/ring/ed25519.rs
+++ b/src/providers/ring/ed25519.rs
@@ -51,7 +51,7 @@ impl Signer for Ed25519Signer {
 pub struct Ed25519Verifier {}
 
 impl Verifier for Ed25519Verifier {
-    fn verify(key: &PublicKey<Self>, msg: &[u8], signature: &Signature) -> Result<(), Error> {
+    fn verify(key: &PublicKey, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         ring::signature::verify(
             &ring::signature::ED25519,
             untrusted::Input::from(key.as_bytes()),

--- a/src/providers/secp256k1/ecdsa.rs
+++ b/src/providers/secp256k1/ecdsa.rs
@@ -1,22 +1,26 @@
-/// ECDSA signer implementation for secp256k1-rs
+/// ECDSA signer implementation for the secp256k1 crate
 
 use generic_array::GenericArray;
 use generic_array::typenum::U32;
 use secp256k1::Message;
 use secp256k1::Secp256k1 as SecpEngine;
 use secp256k1::key::PublicKey as SecpPublicKey;
+use secp256k1::Signature as SecpSignature;
 use secp256k1::key::SecretKey;
 use sha2::{Digest, Sha256};
 
-pub use ecdsa::{FixedSizeInputSigner, Signer};
-use ecdsa::curve::secp256k1::{DERSignature, PublicKey, RawSignature, Secp256k1};
+pub use ecdsa::{FixedSizeInputSigner, FixedSizeInputVerifier, Signer, Verifier};
+pub use ecdsa::curve::secp256k1::{DERSignature, PublicKey, RawSignature};
+use ecdsa::curve::Secp256k1;
 use error::Error;
 
-/// ECDSA signature provider for secp256k1-rs
-pub struct ECDSASigner {
-    /// Secp256k1 signature engine
-    engine: SecpEngine,
+lazy_static! {
+    /// Lazily initialized secp256k1 engine
+    static ref SECP256K1_ENGINE: SecpEngine = SecpEngine::new();
+}
 
+/// ECDSA signature provider for the secp256k1 crate
+pub struct ECDSASigner {
     /// Secp256k1 secret key
     secret_key: SecretKey,
 }
@@ -24,18 +28,17 @@ pub struct ECDSASigner {
 impl ECDSASigner {
     /// Create a new secp256k1 signer from the given private key
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        let engine = SecpEngine::new();
         let secret_key =
-            SecretKey::from_slice(&engine, bytes).map_err(|e| err!(KeyInvalid, "{}", e))?;
+            SecretKey::from_slice(&SECP256K1_ENGINE, bytes).map_err(|e| err!(KeyInvalid, "{}", e))?;
 
-        Ok(Self { engine, secret_key })
+        Ok(Self { secret_key })
     }
 }
 
 impl Signer<Secp256k1> for ECDSASigner {
     /// Return the public key that corresponds to the private key for this signer
     fn public_key(&self) -> Result<PublicKey, Error> {
-        let public_key = SecpPublicKey::from_secret_key(&self.engine, &self.secret_key)
+        let public_key = SecpPublicKey::from_secret_key(&SECP256K1_ENGINE, &self.secret_key)
             .map_err(|e| err!(KeyInvalid, "{}", e))?;
 
         PublicKey::from_bytes(&public_key.serialize()[..])
@@ -57,48 +60,159 @@ impl Signer<Secp256k1> for ECDSASigner {
 impl FixedSizeInputSigner<Secp256k1> for ECDSASigner {
     /// Compute a compact, fixed-sized signature of the given 32-byte message
     fn sign_fixed_raw(&self, msg: &GenericArray<u8, U32>) -> Result<RawSignature, Error> {
-        let signature = self.engine
+        let signature = SECP256K1_ENGINE
             .sign(
                 &Message::from_slice(msg.as_slice()).unwrap(),
                 &self.secret_key,
             )
             .map_err(|e| err!(ProviderError, "{}", e))?;
 
-        Ok(RawSignature::from_bytes(&signature.serialize_compact(&self.engine)[..]).unwrap())
+        Ok(RawSignature::from_bytes(&signature.serialize_compact(&SECP256K1_ENGINE)[..]).unwrap())
     }
 
     /// Compute an ASN.1 DER-encoded signature of the given 32-byte message
     fn sign_fixed_der(&self, msg: &GenericArray<u8, U32>) -> Result<DERSignature, Error> {
-        let signature = self.engine
+        let signature = SECP256K1_ENGINE
             .sign(
                 &Message::from_slice(msg.as_slice()).unwrap(),
                 &self.secret_key,
             )
             .map_err(|e| err!(ProviderError, "{}", e))?;
 
-        Ok(DERSignature::from_bytes(signature.serialize_der(&self.engine)).unwrap())
+        Ok(DERSignature::from_bytes(signature.serialize_der(&SECP256K1_ENGINE)).unwrap())
     }
 }
 
+/// ECDSA verifier provider for the secp256k1 crate
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ECDSAVerifier {}
+
+impl Verifier<Secp256k1> for ECDSAVerifier {
+    /// Verify a fixed-sized (a.k.a. "compact") ECDSA signature against the given public key
+    fn verify_sha2_raw_signature(
+        key: &PublicKey,
+        msg: &[u8],
+        signature: &RawSignature,
+    ) -> Result<(), Error> {
+        Self::verify_fixed_raw_signature(key, &Sha256::digest(msg), signature)
+    }
+
+    /// Verify an ASN.1 DER-encoded ECDSA signature against the given public key
+    fn verify_sha2_der_signature(
+        key: &PublicKey,
+        msg: &[u8],
+        signature: &DERSignature,
+    ) -> Result<(), Error> {
+        Self::verify_fixed_der_signature(key, &Sha256::digest(msg), signature)
+    }
+}
+
+impl FixedSizeInputVerifier<Secp256k1> for ECDSAVerifier {
+    /// Verify a fixed-sized (a.k.a. "compact") ECDSA signature against the given public key
+    fn verify_fixed_raw_signature(
+        key: &PublicKey,
+        msg: &GenericArray<u8, U32>,
+        signature: &RawSignature,
+    ) -> Result<(), Error> {
+        let sig = SecpSignature::from_compact(&SECP256K1_ENGINE, signature.as_bytes()).unwrap();
+        verify_signature(key, msg.as_slice(), &sig)
+    }
+
+    /// Verify an ASN.1 DER-encoded ECDSA signature against the given public key
+    fn verify_fixed_der_signature(
+        key: &PublicKey,
+        msg: &GenericArray<u8, U32>,
+        signature: &DERSignature,
+    ) -> Result<(), Error> {
+        let sig = SecpSignature::from_der(&SECP256K1_ENGINE, signature.as_bytes())
+            .map_err(|e| err!(SignatureInvalid, "{}", e))?;
+
+        verify_signature(key, msg.as_slice(), &sig)
+    }
+}
+
+/// Verify a secp256k1 signature, abstract across the signature type
+///
+/// Panics is the message is not 32-bytes
+fn verify_signature(key: &PublicKey, msg: &[u8], signature: &SecpSignature) -> Result<(), Error> {
+    let pk = SecpPublicKey::from_slice(&SECP256K1_ENGINE, key.as_bytes()).unwrap();
+
+    SECP256K1_ENGINE
+        .verify(&Message::from_slice(msg).unwrap(), signature, &pk)
+        .map_err(|e| err!(SignatureInvalid, "{}", e))
+}
+
+// TODO: test against actual test vectors, rather than just checking if signatures roundtrip
 #[cfg(test)]
 mod tests {
-    use super::{ECDSASigner, Signer};
-    use ecdsa::curve::secp256k1::TEST_VECTORS;
+    use super::{ECDSASigner, ECDSAVerifier, Signer, Verifier};
+    use ecdsa::curve::secp256k1::{DERSignature, RawSignature};
+    // TODO: Actually test against real vectors! These vectors are bogus!
+    use ecdsa::curve::secp256k1::RAW_TEST_VECTORS;
 
-    // TODO: real tests
     #[test]
-    pub fn raw_signature() {
-        let vector = &TEST_VECTORS[0];
+    pub fn raw_signature_roundtrip() {
+        let vector = &RAW_TEST_VECTORS[0];
 
         let signer = ECDSASigner::from_bytes(vector.sk).unwrap();
-        let _signature = signer.sign_sha2_raw(vector.msg).unwrap();
+        let signature = signer.sign_sha2_raw(vector.msg).unwrap();
+
+        let public_key = signer.public_key().unwrap();
+        ECDSAVerifier::verify_sha2_raw_signature(&public_key, vector.msg, &signature).unwrap();
     }
 
     #[test]
-    pub fn asn1_der_signature() {
-        let vector = &TEST_VECTORS[0];
+    pub fn rejects_tweaked_raw_signature() {
+        let vector = &RAW_TEST_VECTORS[0];
 
         let signer = ECDSASigner::from_bytes(vector.sk).unwrap();
-        let _signature = signer.sign_sha2_der(vector.msg).unwrap();
+        let signature = signer.sign_sha2_raw(vector.msg).unwrap();
+        let mut tweaked_signature = signature.into_bytes();
+        tweaked_signature[0] ^= 42;
+
+        let public_key = signer.public_key().unwrap();
+        let result = ECDSAVerifier::verify_sha2_raw_signature(
+            &public_key,
+            vector.msg,
+            &RawSignature::from_bytes(tweaked_signature).unwrap(),
+        );
+
+        assert!(
+            result.is_err(),
+            "expected bad signature to cause validation error!"
+        );
+    }
+
+    #[test]
+    pub fn asn1_der_signature_roundtrip() {
+        let vector = &RAW_TEST_VECTORS[0];
+
+        let signer = ECDSASigner::from_bytes(vector.sk).unwrap();
+        let signature = signer.sign_sha2_der(vector.msg).unwrap();
+
+        let public_key = signer.public_key().unwrap();
+        ECDSAVerifier::verify_sha2_der_signature(&public_key, vector.msg, &signature).unwrap();
+    }
+
+    #[test]
+    pub fn rejects_tweaked_asn1_der_signature() {
+        let vector = &RAW_TEST_VECTORS[0];
+
+        let signer = ECDSASigner::from_bytes(vector.sk).unwrap();
+        let signature = signer.sign_sha2_der(vector.msg).unwrap();
+        let mut tweaked_signature = signature.into_bytes();
+        tweaked_signature[0] ^= 42;
+
+        let public_key = signer.public_key().unwrap();
+        let result = ECDSAVerifier::verify_sha2_der_signature(
+            &public_key,
+            vector.msg,
+            &DERSignature::from_bytes(tweaked_signature).unwrap(),
+        );
+
+        assert!(
+            result.is_err(),
+            "expected bad signature to cause validation error!"
+        );
     }
 }

--- a/src/providers/secp256k1/mod.rs
+++ b/src/providers/secp256k1/mod.rs
@@ -5,4 +5,4 @@
 
 mod ecdsa;
 
-pub use self::ecdsa::ECDSASigner;
+pub use self::ecdsa::{ECDSASigner, ECDSAVerifier};

--- a/src/providers/sodiumoxide/ed25519.rs
+++ b/src/providers/sodiumoxide/ed25519.rs
@@ -49,7 +49,7 @@ impl Signer for Ed25519Signer {
 pub struct Ed25519Verifier {}
 
 impl Verifier for Ed25519Verifier {
-    fn verify(key: &PublicKey<Self>, msg: &[u8], signature: &Signature) -> Result<(), Error> {
+    fn verify(key: &PublicKey, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         let pk = sodiumoxide_ed25519::PublicKey::from_slice(key.as_bytes()).unwrap();
         let sig = sodiumoxide_ed25519::Signature::from_slice(signature.as_ref()).unwrap();
 


### PR DESCRIPTION
Adds a set of traits for verifying ECDSA signatures:

* `ecdsa::verifier::Verifier<C>`: verify SHA-2 message digest
* `ecdsa::verifier::FixedSizedInputVerifier<C>`: verify raw message

Implements these traits for the secp256k1-rs provider