### PR TITLE
Mark all Signers and Verifiers as Send safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ nightly = ["ed25519-dalek/nightly"]
 std = []
 ring-provider = ["ed25519", "ring", "untrusted"]
 secp256k1-provider = ["ecdsa", "lazy_static", "secp256k1", "sha2", "std"]
-sodiumoxide-provider = ["ed25519", "sodiumoxide"]
+sodiumoxide-provider = ["ed25519", "sodiumoxide", "std"]
 yubihsm-provider = ["ed25519", "std", "yubihsm"]
 yubihsm-mockhsm = ["yubihsm-provider", "yubihsm/mockhsm"]
 

--- a/src/ecdsa/curve/mod.rs
+++ b/src/ecdsa/curve/mod.rs
@@ -10,7 +10,9 @@ pub use self::secp256k1::Secp256k1;
 use super::verifier::Verifier;
 
 /// Elliptic curve in short Weierstrass form suitable for use with ECDSA
-pub trait WeierstrassCurve: Clone + Debug + Default + Hash + Eq + PartialEq + Sync + Sized {
+pub trait WeierstrassCurve:
+    Clone + Debug + Default + Hash + Eq + PartialEq + Send + Sized + Sync
+{
     /// Size of a private scalar for this elliptic curve in bytes
     type PrivateKeySize: ArrayLength<u8>;
 

--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -15,7 +15,7 @@ use super::curve::WeierstrassCurve;
 ///
 /// NOTE: Support is not (yet) provided for mixing and matching curve and
 /// digest sizes. If you are interested in this, please open an issue.
-pub trait Signer<C: WeierstrassCurve>: Sync {
+pub trait Signer<C: WeierstrassCurve>: Send + Sized + Sync {
     /// Obtain the public key which identifies this signer
     fn public_key(&self) -> Result<PublicKey<C>, Error>;
 
@@ -31,7 +31,7 @@ pub trait Signer<C: WeierstrassCurve>: Sync {
 
 /// Sign a raw message the same size as the curve's field (i.e. without first
 /// computing a SHA-2 digest of the message)
-pub trait FixedSizeInputSigner<C: WeierstrassCurve>: Sync {
+pub trait FixedSizeInputSigner<C: WeierstrassCurve>: Send + Sized + Sync {
     /// Compute a compact, fixed-width signature of a fixed-sized message
     /// whose length matches the size of the curve's field.
     fn sign_fixed_raw(

--- a/src/ecdsa/verifier.rs
+++ b/src/ecdsa/verifier.rs
@@ -17,7 +17,7 @@ use super::curve::WeierstrassCurve;
 ///
 /// NOTE: Support is not (yet) provided for mixing and matching curve and
 /// digest sizes. If you are interested in this, please open an issue.
-pub trait Verifier<C>: Clone + Debug + Hash + Eq + PartialEq + Sync + Sized
+pub trait Verifier<C>: Clone + Debug + Hash + Eq + PartialEq + Send + Sized + Sync
 where
     C: WeierstrassCurve,
 {
@@ -39,7 +39,7 @@ where
 
 /// Verify a raw message the same size as the curve's field (i.e. without first
 /// computing a SHA-2 digest of the message)
-pub trait FixedSizeInputVerifier<C: WeierstrassCurve>: Verifier<C> + Sync {
+pub trait FixedSizeInputVerifier<C: WeierstrassCurve>: Send + Sized + Sync {
     /// Verify a compact, fixed-width signature of a fixed-sized message
     /// whose length matches the size of the curve's field.
     fn verify_fixed_raw_signature(

--- a/src/ed25519/signer.rs
+++ b/src/ed25519/signer.rs
@@ -14,7 +14,7 @@ pub trait FromSeed: Sized {
 }
 
 /// Trait for Ed25519 signers (object-safe)
-pub trait Signer: Sync {
+pub trait Signer: Send + Sized + Sync {
     /// Obtain the public key which identifies this signer
     fn public_key(&self) -> Result<PublicKey, Error>;
 

--- a/src/ed25519/verifier.rs
+++ b/src/ed25519/verifier.rs
@@ -19,7 +19,7 @@ use error::Error;
 use super::{PublicKey, Signature};
 
 /// Verifier for Ed25519 signatures
-pub trait Verifier: Clone + Debug + Hash + Eq + PartialEq + Sync + Sized {
+pub trait Verifier: Clone + Debug + Hash + Eq + PartialEq + Send + Sized + Sync {
     /// Verify an Ed25519 signature against the given public key
     fn verify(key: &PublicKey, msg: &[u8], signature: &Signature) -> Result<(), Error>;
 }


### PR DESCRIPTION
They already were. We just didn't mark them as such.