### PR TITLE
Fix benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,33 +24,39 @@ jobs:
       - run:
           name: build (stable, no default features + ecdsa + ed25519)
           command: |
-            rustc --version --verbose
-            cargo --version --verbose
+            rustc --version
+            cargo --version
             cargo build --no-default-features --features=ecdsa,ed25519
       - run:
           name: build (stable, default features only)
           command: |
-            rustc --version --verbose
-            cargo --version --verbose
+            rustc --version
+            cargo --version
             cargo build
       - run:
           name: test (stable, default features only)
           command: |
-            rustc --version --verbose
-            cargo --version --verbose
+            rustc --version
+            cargo --version
             cargo test
       - run:
           name: build (nightly, all features)
           command: |
-            rustup run $RUST_NIGHTLY_VERSION rustc --version --verbose
-            rustup run $RUST_NIGHTLY_VERSION cargo --version --verbose
-            rustup run $RUST_NIGHTLY_VERSION cargo build --features=$CARGO_FEATURES
+            rustup run $RUST_NIGHTLY_VERSION rustc --version
+            rustup run $RUST_NIGHTLY_VERSION cargo --version
+            rustup run $RUST_NIGHTLY_VERSION cargo build --features=nightly,$CARGO_FEATURES
       - run:
           name: test (nightly, all features)
           command: |
-            rustup run $RUST_NIGHTLY_VERSION rustc --version --verbose
-            rustup run $RUST_NIGHTLY_VERSION cargo --version --verbose
-            rustup run $RUST_NIGHTLY_VERSION cargo test --features=$CARGO_FEATURES
+            rustup run $RUST_NIGHTLY_VERSION rustc --version
+            rustup run $RUST_NIGHTLY_VERSION cargo --version
+            rustup run $RUST_NIGHTLY_VERSION cargo test --features=nightly,$CARGO_FEATURES
+      - run:
+          name: bench (nightly, all features)
+          command: |
+            rustup run $RUST_NIGHTLY_VERSION rustc --version
+            rustup run $RUST_NIGHTLY_VERSION cargo --version
+            rustup run $RUST_NIGHTLY_VERSION cargo bench --features=nightly,$CARGO_FEATURES
       - save_cache:
           key: cache-201804090 # bump restore_cache key above too
           paths:

--- a/benches/ed25519.rs
+++ b/benches/ed25519.rs
@@ -1,4 +1,7 @@
-/// Ed25519 provider benchmarks
+//! Ed25519 provider benchmarks
+
+#![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
+#![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 
 #[macro_use]
 extern crate criterion;
@@ -14,7 +17,7 @@ const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
 #[cfg(feature = "dalek-provider")]
 mod dalek_benches {
     use super::*;
-    use signatory::ed25519::Signer;
+    use signatory::ed25519::{FromSeed, Signer, Verifier};
     use signatory::providers::dalek::{Ed25519Signer, Ed25519Verifier};
 
     fn sign(c: &mut Criterion) {
@@ -26,11 +29,11 @@ mod dalek_benches {
     }
 
     fn verify(c: &mut Criterion) {
-        let public_key = PublicKey::<Ed25519Verifier>::from_bytes(TEST_VECTOR.pk).unwrap();
+        let public_key = PublicKey::from_bytes(TEST_VECTOR.pk).unwrap();
         let signature = Signature::from_bytes(TEST_VECTOR.sig).unwrap();
 
         c.bench_function("dalek: ed25519 verifier", move |b| {
-            b.iter(|| public_key.verify(TEST_VECTOR.msg, &signature).unwrap())
+            b.iter(|| Ed25519Verifier::verify(&public_key, TEST_VECTOR.msg, &signature).unwrap())
         });
     }
 
@@ -44,7 +47,7 @@ mod dalek_benches {
 #[cfg(feature = "ring-provider")]
 mod ring_benches {
     use super::*;
-    use signatory::ed25519::Signer;
+    use signatory::ed25519::{FromSeed, Signer, Verifier};
     use signatory::providers::ring::{Ed25519Signer, Ed25519Verifier};
 
     fn sign(c: &mut Criterion) {
@@ -56,11 +59,11 @@ mod ring_benches {
     }
 
     fn verify(c: &mut Criterion) {
-        let public_key = PublicKey::<Ed25519Verifier>::from_bytes(TEST_VECTOR.pk).unwrap();
+        let public_key = PublicKey::from_bytes(TEST_VECTOR.pk).unwrap();
         let signature = Signature::from_bytes(TEST_VECTOR.sig).unwrap();
 
         c.bench_function("ring: ed25519 verifier", move |b| {
-            b.iter(|| public_key.verify(TEST_VECTOR.msg, &signature).unwrap())
+            b.iter(|| Ed25519Verifier::verify(&public_key, TEST_VECTOR.msg, &signature).unwrap())
         });
     }
 
@@ -74,7 +77,7 @@ mod ring_benches {
 #[cfg(feature = "sodiumoxide-provider")]
 mod sodiumoxide_benches {
     use super::*;
-    use signatory::ed25519::Signer;
+    use signatory::ed25519::{FromSeed, Signer, Verifier};
     use signatory::providers::sodiumoxide::{Ed25519Signer, Ed25519Verifier};
 
     fn sign(c: &mut Criterion) {
@@ -86,11 +89,11 @@ mod sodiumoxide_benches {
     }
 
     fn verify(c: &mut Criterion) {
-        let public_key = PublicKey::<Ed25519Verifier>::from_bytes(TEST_VECTOR.pk).unwrap();
+        let public_key = PublicKey::from_bytes(TEST_VECTOR.pk).unwrap();
         let signature = Signature::from_bytes(TEST_VECTOR.sig).unwrap();
 
         c.bench_function("sodiumoxide: ed25519 verifier", move |b| {
-            b.iter(|| public_key.verify(TEST_VECTOR.msg, &signature).unwrap())
+            b.iter(|| Ed25519Verifier::verify(&public_key, TEST_VECTOR.msg, &signature).unwrap())
         });
     }
 


### PR DESCRIPTION
Benchmarks were not previously covered by CI, and broke due to API changes.

This updates the benchmarks to use the new API, and adds them to CI to ensure they aren't broken by future API changes.

Ideally we'd just ensure the benchmarks compile as opposed to actually running them in CI, but I can't figure out exactly how to do that with criterion.