### PR TITLE
No default features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,17 +23,17 @@ jobs:
             cargo +$RUST_NIGHTLY_VERSION clippy --version
             cargo +$RUST_NIGHTLY_VERSION clippy --all-features
       - run:
-          name: build (--no-default-features + ecdsa + ed25519)
+          name: build (ecdsa feature only)
           command: |
             rustc --version
             cargo --version
-            cargo build --no-default-features --features=ecdsa,ed25519
+            cargo build --features=ecdsa
       - run:
-          name: build (default features)
+          name: build (ed25519 feature only)
           command: |
             rustc --version
             cargo --version
-            cargo build --benches --all
+            cargo build --features=ed25519
       - run:
           name: build (all features except nightly)
           command: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ criterion = "0.2"
 
 [features]
 dalek-provider = ["ed25519", "ed25519-dalek", "sha2"]
-default = ["dalek-provider"]
 ecdsa = ["generic-array"]
 ed25519 = ["clear_on_drop", "rand"]
 nightly = ["clear_on_drop/nightly", "ed25519-dalek/nightly", "yubihsm/nightly"]


### PR DESCRIPTION
It made sense for Signatory to include the ed25519-dalek provider by default when it was only an Ed25519 library, but now that it also supports ECDSA it doesn't make sense to rope in an Ed25519 dependency by default.