### PR TITLE
Factor ECDSA traits apart into separate traits per method

### DIFF
--- a/src/ecdsa/curve/mod.rs
+++ b/src/ecdsa/curve/mod.rs
@@ -7,7 +7,6 @@ use core::hash::Hash;
 use generic_array::ArrayLength;
 
 pub use self::secp256k1::Secp256k1;
-use super::verifier::Verifier;
 
 /// Elliptic curve in short Weierstrass form suitable for use with ECDSA
 pub trait WeierstrassCurve:
@@ -20,8 +19,5 @@ pub trait WeierstrassCurve:
     type PublicKeySize: ArrayLength<u8>;
 
     /// Size of a compact, fixed-sized signature for this curve
-    type RawSignatureSize: ArrayLength<u8>;
-
-    /// Default ECDSA verification provider to use for this curve
-    type DefaultSignatureVerifier: Verifier<Self>;
+    type FixedSignatureSize: ArrayLength<u8>;
 }

--- a/src/ecdsa/curve/secp256k1/mod.rs
+++ b/src/ecdsa/curve/secp256k1/mod.rs
@@ -7,10 +7,6 @@ mod test_vectors;
 use generic_array::typenum::{U32, U33, U64};
 
 use super::WeierstrassCurve;
-#[cfg(feature = "std")]
-use ecdsa::DERSignature as GenericDERSignature;
-use ecdsa::PublicKey as GenericPublicKey;
-use ecdsa::RawSignature as GenericRawSignature;
 
 // TODO: mark these as pub when we have a well-vetted set of test vectors
 #[allow(unused_imports)]
@@ -23,21 +19,15 @@ pub struct Secp256k1;
 impl WeierstrassCurve for Secp256k1 {
     type PrivateKeySize = U32;
     type PublicKeySize = U33;
-    type RawSignatureSize = U64;
-
-    #[cfg(feature = "secp256k1-provider")]
-    type DefaultSignatureVerifier = ::providers::secp256k1::ECDSAVerifier;
-
-    #[cfg(not(feature = "secp256k1-provider"))]
-    type DefaultSignatureVerifier = ::ecdsa::verifier::PanickingVerifier<Self>;
+    type FixedSignatureSize = U64;
 }
 
 /// secp256k1 public key
-pub type PublicKey = GenericPublicKey<Secp256k1>;
-
-/// Compact, fixed-sized secp256k1 ECDSA signature
-pub type RawSignature = GenericRawSignature<Secp256k1>;
+pub type PublicKey = ::ecdsa::PublicKey<Secp256k1>;
 
 /// ASN.1 DER encoded secp256k1 ECDSA signature
 #[cfg(feature = "std")]
-pub type DERSignature = GenericDERSignature<Secp256k1>;
+pub type DERSignature = ::ecdsa::signature::DERSignature<Secp256k1>;
+
+/// Compact, fixed-sized secp256k1 ECDSA signature
+pub type FixedSignature = ::ecdsa::signature::FixedSignature<Secp256k1>;

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -4,13 +4,9 @@
 pub mod curve;
 mod public_key;
 mod signature;
-mod signer;
-mod verifier;
+pub mod signer;
+pub mod verifier;
 
 pub use self::curve::Secp256k1;
 pub use self::public_key::PublicKey;
-#[cfg(feature = "std")]
-pub use self::signature::DERSignature;
-pub use self::signature::RawSignature;
-pub use self::signer::{FixedSizeInputSigner, Signer};
-pub use self::verifier::{FixedSizeInputVerifier, Verifier};
+pub use self::signature::*;

--- a/src/ecdsa/public_key.rs
+++ b/src/ecdsa/public_key.rs
@@ -6,9 +6,6 @@ use generic_array::typenum::Unsigned;
 use generic_array::GenericArray;
 
 use super::curve::WeierstrassCurve;
-#[cfg(feature = "std")]
-use super::DERSignature;
-use super::{RawSignature, Verifier};
 use error::Error;
 use util::fmt_colon_delimited_hex;
 
@@ -52,27 +49,6 @@ impl<C: WeierstrassCurve> PublicKey<C> {
     #[inline]
     pub fn into_bytes(self) -> GenericArray<u8, C::PublicKeySize> {
         self.bytes
-    }
-
-    /// Verify a fixed-sized (a.k.a. "compact") ECDSA signature
-    #[inline]
-    pub fn verify_sha2_raw_signature(
-        &self,
-        msg: &[u8],
-        signature: &RawSignature<C>,
-    ) -> Result<(), Error> {
-        C::DefaultSignatureVerifier::verify_sha2_raw_signature(self, msg, signature)
-    }
-
-    /// Verify an ASN.1 DER-encoded ECDSA signature
-    #[cfg(feature = "std")]
-    #[inline]
-    pub fn verify_sha2_der_signature(
-        &self,
-        msg: &[u8],
-        signature: &DERSignature<C>,
-    ) -> Result<(), Error> {
-        C::DefaultSignatureVerifier::verify_sha2_der_signature(self, msg, signature)
     }
 }
 

--- a/src/ecdsa/signature/der.rs
+++ b/src/ecdsa/signature/der.rs
@@ -1,14 +1,18 @@
-//! ASN.1 DER-serialized ECDSA signatures
+//! ASN.1 DER-encoded ECDSA signatures
+//!
+//! Presently requires 'std' as these signatures are variable-sized and the
+//! current implementation is backed by a `Vec<u8>`.
 
-use std::fmt;
+use std::fmt::{self, Debug};
 use std::marker::PhantomData;
+// TODO: no_std support (with 'alloc' crate or fixed sized array)
 use std::vec::Vec;
 
 use ecdsa::curve::WeierstrassCurve;
 use error::Error;
 use util::fmt_colon_delimited_hex;
 
-/// ECDSA signatures serialized as ASN.1 DER
+/// ECDSA signatures encoded as ASN.1 DER
 #[derive(Clone, PartialEq, Eq)]
 pub struct DERSignature<C: WeierstrassCurve> {
     /// Signature data as bytes
@@ -19,7 +23,7 @@ pub struct DERSignature<C: WeierstrassCurve> {
 }
 
 impl<C: WeierstrassCurve> DERSignature<C> {
-    /// Create an ECDSA signature from its serialized byte representation
+    /// Create an ASN.1 DER-encoded ECDSA signature from its serialized byte representation
     pub fn from_bytes<B>(bytes: B) -> Result<Self, Error>
     where
         B: Into<Vec<u8>>,
@@ -50,9 +54,9 @@ impl<C: WeierstrassCurve> AsRef<[u8]> for DERSignature<C> {
     }
 }
 
-impl<C: WeierstrassCurve> fmt::Debug for DERSignature<C> {
+impl<C: WeierstrassCurve> Debug for DERSignature<C> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "signatory::ecdsa::Signature<{:?}>(", C::default())?;
+        write!(f, "signatory::ecdsa::DERSignature<{:?}>(", C::default())?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
         write!(f, ")")
     }

--- a/src/ecdsa/signature/fixed.rs
+++ b/src/ecdsa/signature/fixed.rs
@@ -1,6 +1,6 @@
-//! Raw (a.k.a. compact, fixed-sized) ECDSA signatures as seen with e.g. PKCS#11
+//! Fixed-size, compact ECDSA signatures (as used in e.g. PKCS#11)
 
-use core::fmt;
+use core::fmt::{self, Debug};
 use core::marker::PhantomData;
 use generic_array::typenum::Unsigned;
 use generic_array::GenericArray;
@@ -11,25 +11,25 @@ use util::fmt_colon_delimited_hex;
 
 /// ECDSA signatures serialized in a compact, fixed-sized form
 #[derive(Clone, PartialEq, Eq)]
-pub struct RawSignature<C: WeierstrassCurve> {
+pub struct FixedSignature<C: WeierstrassCurve> {
     /// Signature data as bytes
-    bytes: GenericArray<u8, C::RawSignatureSize>,
+    bytes: GenericArray<u8, C::FixedSignatureSize>,
 
     /// Placeholder for elliptic curve type
     curve: PhantomData<C>,
 }
 
-impl<C: WeierstrassCurve> RawSignature<C> {
+impl<C: WeierstrassCurve> FixedSignature<C> {
     /// Create an ECDSA signature from its serialized byte representation
     pub fn from_bytes<B>(bytes: B) -> Result<Self, Error>
     where
         B: AsRef<[u8]>,
     {
         ensure!(
-            bytes.as_ref().len() == C::RawSignatureSize::to_usize(),
+            bytes.as_ref().len() == C::FixedSignatureSize::to_usize(),
             SignatureInvalid,
             "expected {}-byte signature (got {})",
-            C::RawSignatureSize::to_usize(),
+            C::FixedSignatureSize::to_usize(),
             bytes.as_ref().len()
         );
 
@@ -47,20 +47,20 @@ impl<C: WeierstrassCurve> RawSignature<C> {
 
     /// Convert signature into owned byte array
     #[inline]
-    pub fn into_bytes(self) -> GenericArray<u8, C::RawSignatureSize> {
+    pub fn into_bytes(self) -> GenericArray<u8, C::FixedSignatureSize> {
         self.bytes
     }
 }
 
-impl<C: WeierstrassCurve> AsRef<[u8]> for RawSignature<C> {
+impl<C: WeierstrassCurve> AsRef<[u8]> for FixedSignature<C> {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<C: WeierstrassCurve> fmt::Debug for RawSignature<C> {
+impl<C: WeierstrassCurve> Debug for FixedSignature<C> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "signatory::ecdsa::Signature<{:?}>(", C::default())?;
+        write!(f, "signatory::ecdsa::FixedSignature<{:?}>(", C::default())?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
         write!(f, ")")
     }

--- a/src/ecdsa/signature/mod.rs
+++ b/src/ecdsa/signature/mod.rs
@@ -1,10 +1,12 @@
-//! ECDSA signatures. ASN.1 signatures are variable-sized and therefore require
-//! `std` for `Vec` support.
+//! ECDSA signatures:
+//!
+//! - ASN.1 DER signatures (requires `std` as they're backed by `Vec`)
+//! - Fixed sized signatures
 
 #[cfg(feature = "std")]
-mod asn1;
-mod raw;
+mod der;
+mod fixed;
 
 #[cfg(feature = "std")]
-pub use self::asn1::DERSignature;
-pub use self::raw::RawSignature;
+pub use self::der::DERSignature;
+pub use self::fixed::FixedSignature;

--- a/src/ecdsa/signer.rs
+++ b/src/ecdsa/signer.rs
@@ -1,49 +1,91 @@
 //! Trait for ECDSA signers
 
-use generic_array::GenericArray;
+use generic_array::{typenum::U32, GenericArray};
+#[cfg(feature = "sha2")]
+use sha2::{Digest, Sha256};
 
-use super::curve::WeierstrassCurve;
 #[cfg(feature = "std")]
 use super::DERSignature;
-use super::{PublicKey, RawSignature};
+use super::{curve::WeierstrassCurve, FixedSignature, PublicKey};
 use error::Error;
 
-/// Trait for ECDSA signers (object safe)
-///
-/// When using this trait, the message will first be hashed using the SHA-2
-/// function whose digest size matches the size of the elliptic curve's field.
-///
-/// NOTE: Support is not (yet) provided for mixing and matching curve and
-/// digest sizes. If you are interested in this, please open an issue.
+/// ECDSA signer base trait
 pub trait Signer<C: WeierstrassCurve>: Send + Sync {
     /// Obtain the public key which identifies this signer
     fn public_key(&self) -> Result<PublicKey<C>, Error>;
-
-    /// Compute a compact, fixed-width ECDSA signature for the SHA-256 digest
-    /// of the given message.
-    fn sign_sha2_raw(&self, msg: &[u8]) -> Result<RawSignature<C>, Error>;
-
-    /// Compute an ASN.1 DER-encoded ECDSA signature for the SHA-256 digest
-    /// of the given message.
-    #[cfg(feature = "std")]
-    fn sign_sha2_der(&self, msg: &[u8]) -> Result<DERSignature<C>, Error>;
 }
 
-/// Sign a raw message the same size as the curve's field (i.e. without first
-/// computing a SHA-2 digest of the message)
-pub trait FixedSizeInputSigner<C: WeierstrassCurve>: Send + Sync {
-    /// Compute a compact, fixed-width signature of a fixed-sized message
-    /// whose length matches the size of the curve's field.
-    fn sign_fixed_raw(
-        &self,
-        msg: &GenericArray<u8, C::PrivateKeySize>,
-    ) -> Result<RawSignature<C>, Error>;
+/// ECDSA signer which computes SHA-256 digests of messages and returns
+/// ASN.1 DER-encoded signatures
+#[cfg(feature = "std")]
+pub trait SHA256DERSigner<C>: Signer<C>
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+{
+    /// Compute an ASN.1 DER-encoded ECDSA signature for the SHA-256 digest
+    /// of the given message.
+    fn sign_sha256_der(&self, msg: &[u8]) -> Result<DERSignature<C>, Error>;
+}
 
+/// ECDSA signer which computes SHA-256 digests of messages and returns
+/// fixed-width encoded signatures
+pub trait SHA256FixedSigner<C>: Signer<C>
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+{
+    /// Compute a compact, fixed-width ECDSA signature for the SHA-256 digest
+    /// of the given message.
+    fn sign_sha256_fixed(&self, msg: &[u8]) -> Result<FixedSignature<C>, Error>;
+}
+
+/// Sign a raw digest the same size as the curve's field (i.e. without first
+/// computing a SHA-2 digest of the message) returning an ASN.1 DER signature
+#[cfg(feature = "std")]
+pub trait RawDigestDERSigner<C>: Signer<C>
+where
+    C: WeierstrassCurve,
+{
     /// Compute an ASN.1 DER encoded signature of a fixed-sized message
     /// whose length matches the size of the curve's field.
     #[cfg(feature = "std")]
-    fn sign_fixed_der(
+    fn sign_digest_der(
         &self,
-        msg: &GenericArray<u8, C::PrivateKeySize>,
+        digest: &GenericArray<u8, C::PrivateKeySize>,
     ) -> Result<DERSignature<C>, Error>;
+}
+
+/// Sign a raw digest the same size as the curve's field (i.e. without first
+/// computing a SHA-2 digest of the message) returning a fixed-width signature
+pub trait RawDigestFixedSigner<C>: Signer<C>
+where
+    C: WeierstrassCurve,
+{
+    /// Compute a compact, fixed-width signature of a fixed-sized message
+    /// whose length matches the size of the curve's field.
+    fn sign_digest_fixed(
+        &self,
+        digest: &GenericArray<u8, C::PrivateKeySize>,
+    ) -> Result<FixedSignature<C>, Error>;
+}
+
+#[cfg(feature = "sha2")]
+impl<C, S> SHA256DERSigner<C> for S
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+    S: RawDigestDERSigner<C>,
+{
+    fn sign_sha256_der(&self, msg: &[u8]) -> Result<DERSignature<C>, Error> {
+        self.sign_digest_der(&Sha256::digest(msg))
+    }
+}
+
+#[cfg(feature = "sha2")]
+impl<C, S> SHA256FixedSigner<C> for S
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+    S: RawDigestFixedSigner<C>,
+{
+    fn sign_sha256_fixed(&self, msg: &[u8]) -> Result<FixedSignature<C>, Error> {
+        self.sign_digest_fixed(&Sha256::digest(msg))
+    }
 }

--- a/src/ecdsa/verifier.rs
+++ b/src/ecdsa/verifier.rs
@@ -1,14 +1,13 @@
 //! Trait for ECDSA verifiers
 
-use core::fmt::Debug;
-use core::hash::Hash;
-use core::marker::PhantomData;
-use generic_array::GenericArray;
+use core::{fmt::Debug, hash::Hash};
+use generic_array::{typenum::U32, GenericArray};
+#[cfg(feature = "sha2")]
+use sha2::{Digest, Sha256};
 
-use super::curve::WeierstrassCurve;
 #[cfg(feature = "std")]
 use super::DERSignature;
-use super::{PublicKey, RawSignature};
+use super::{curve::WeierstrassCurve, FixedSignature, PublicKey};
 use error::Error;
 
 /// Verifier for ECDSA signatures which first hashes the input message using
@@ -17,70 +16,94 @@ use error::Error;
 ///
 /// NOTE: Support is not (yet) provided for mixing and matching curve and
 /// digest sizes. If you are interested in this, please open an issue.
-pub trait Verifier<C>: Clone + Debug + Hash + Eq + PartialEq + Send + Sync
+pub trait SHA256DERVerifier<C>: Clone + Debug + Hash + Eq + PartialEq + Send + Sync
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+{
+    /// Verify an ASN.1 DER-encoded ECDSA signature against the given public key
+    #[cfg(feature = "std")]
+    fn verify_sha256_der_signature(
+        key: &PublicKey<C>,
+        msg: &[u8],
+        signature: &DERSignature<C>,
+    ) -> Result<(), Error>;
+}
+
+/// Verifier for ECDSA signatures which first hashes the input message using
+/// the SHA-2 function whose digest matches the size of the elliptic curve's
+/// field.
+///
+/// NOTE: Support is not (yet) provided for mixing and matching curve and
+/// digest sizes. If you are interested in this, please open an issue.
+pub trait SHA256FixedVerifier<C>: Clone + Debug + Hash + Eq + PartialEq + Send + Sync
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+{
+    /// Verify a fixed-sized (a.k.a. "compact") ECDSA signature against the given public key
+    fn verify_sha256_fixed_signature(
+        key: &PublicKey<C>,
+        msg: &[u8],
+        signature: &FixedSignature<C>,
+    ) -> Result<(), Error>;
+}
+
+/// Verify a raw message the same size as the curve's field (i.e. without first
+/// computing a SHA-2 digest of the message)
+pub trait RawDigestDERVerifier<C>: Clone + Debug + Hash + Eq + PartialEq + Send + Sync
 where
     C: WeierstrassCurve,
 {
-    /// Verify a fixed-sized (a.k.a. "compact") ECDSA signature against the given public key
-    fn verify_sha2_raw_signature(
-        key: &PublicKey<C>,
-        msg: &[u8],
-        signature: &RawSignature<C>,
-    ) -> Result<(), Error>;
-
-    /// Verify an ASN.1 DER-encoded ECDSA signature against the given public key
+    /// Verify an ASN.1 DER encoded signature of a fixed-sized message
+    /// whose length matches the size of the curve's field.
     #[cfg(feature = "std")]
-    fn verify_sha2_der_signature(
+    fn verify_digest_der_signature(
         key: &PublicKey<C>,
-        msg: &[u8],
+        digest: &GenericArray<u8, C::PrivateKeySize>,
         signature: &DERSignature<C>,
     ) -> Result<(), Error>;
 }
 
 /// Verify a raw message the same size as the curve's field (i.e. without first
 /// computing a SHA-2 digest of the message)
-pub trait FixedSizeInputVerifier<C: WeierstrassCurve>: Send + Sync {
+pub trait RawDigestFixedVerifier<C>: Clone + Debug + Hash + Eq + PartialEq + Send + Sync
+where
+    C: WeierstrassCurve,
+{
     /// Verify a compact, fixed-width signature of a fixed-sized message
     /// whose length matches the size of the curve's field.
-    fn verify_fixed_raw_signature(
+    fn verify_digest_fixed_signature(
         key: &PublicKey<C>,
-        msg: &GenericArray<u8, C::PrivateKeySize>,
-        signature: &RawSignature<C>,
+        digest: &GenericArray<u8, C::PrivateKeySize>,
+        signature: &FixedSignature<C>,
     ) -> Result<(), Error>;
+}
 
-    /// Verify an ASN.1 DER encoded signature of a fixed-sized message
-    /// whose length matches the size of the curve's field.
-    #[cfg(feature = "std")]
-    fn verify_fixed_der_signature(
+#[cfg(feature = "sha2")]
+impl<C, V> SHA256DERVerifier<C> for V
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+    V: RawDigestDERVerifier<C>,
+{
+    fn verify_sha256_der_signature(
         key: &PublicKey<C>,
-        msg: &GenericArray<u8, C::PrivateKeySize>,
+        msg: &[u8],
         signature: &DERSignature<C>,
-    ) -> Result<(), Error>;
-}
-
-/// A panicking verifier we can use as the default if no other verifiers are available
-#[allow(dead_code)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct PanickingVerifier<C: WeierstrassCurve> {
-    c: PhantomData<C>,
-}
-
-#[allow(dead_code)]
-impl<C: WeierstrassCurve> Verifier<C> for PanickingVerifier<C> {
-    fn verify_sha2_raw_signature(
-        _key: &PublicKey<C>,
-        _msg: &[u8],
-        _signature: &RawSignature<C>,
     ) -> Result<(), Error> {
-        panic!("no default provider available for {:?} ECDSA", C::default());
+        Self::verify_digest_der_signature(key, &Sha256::digest(msg), signature)
     }
+}
 
-    #[cfg(feature = "std")]
-    fn verify_sha2_der_signature(
-        _key: &PublicKey<C>,
-        _msg: &[u8],
-        _signature: &DERSignature<C>,
+#[cfg(feature = "sha2")]
+impl<C, V> SHA256FixedVerifier<C> for V
+where
+    C: WeierstrassCurve<PrivateKeySize = U32>,
+    V: RawDigestFixedVerifier<C>,
+{
+    fn verify_sha256_fixed_signature(
+        key: &PublicKey<C>,
+        msg: &[u8],
+        signature: &FixedSignature<C>,
     ) -> Result<(), Error> {
-        panic!("no default provider available for {:?} ECDSA", C::default());
+        Self::verify_digest_fixed_signature(key, &Sha256::digest(msg), signature)
     }
 }

--- a/src/ed25519/verifier.rs
+++ b/src/ed25519/verifier.rs
@@ -49,6 +49,6 @@ pub struct DefaultVerifier {}
 )]
 impl Verifier for DefaultVerifier {
     fn verify(_key: &PublicKey, _msg: &[u8], _signature: &Signature) -> Result<(), Error> {
-        panic!("no Ed25519 providers enabled when signatory was built");
+        panic!("no Ed25519 providers available");
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,10 +123,18 @@ macro_rules! err {
         )
     };
     ($variant:ident, $fmt:expr, $($arg:tt)+) => {
-        ::error::Error::new(
-            ::error::ErrorKind::$variant,
-            Some(&format!($fmt, $($arg)+))
-        )
+        err!($variant, &format!($fmt, $($arg)+))
+    };
+}
+
+/// Create and return an error with a formatted message
+#[allow(unused_macros)]
+macro_rules! fail {
+    ($kind:ident, $msg:expr) => {
+        return Err(err!($kind, $msg).into());
+    };
+    ($kind:ident, $fmt:expr, $($arg:tt)+) => {
+        return Err(err!($kind, $fmt, $($arg)+).into());
     };
 }
 


### PR DESCRIPTION
Splits ECDSA traits up so signers can implement any combination of:

- Signing hashed messages (SHA-256 only) versus raw digests
- Producing ASN.1 DER signatures versus fixed-sized signatures

This removes support for default ECDSA verifiers, but we can add that back with a more sensible API.