### PR TITLE
ECDSA support for yubihsm-provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ring-provider = ["ecdsa", "ed25519", "ring", "untrusted"]
 secp256k1-provider = ["ecdsa", "lazy_static", "secp256k1", "sha2", "std"]
 sodiumoxide-provider = ["ed25519", "sodiumoxide", "std"]
 test-vectors = []
-yubihsm-provider = ["ed25519", "std", "yubihsm"]
+yubihsm-provider = ["ecdsa", "ed25519", "std", "yubihsm"]
 yubihsm-mockhsm = ["yubihsm-provider", "yubihsm/mockhsm"]
 
 [package.metadata.docs.rs]

--- a/src/ecdsa/curve/mod.rs
+++ b/src/ecdsa/curve/mod.rs
@@ -14,6 +14,17 @@ pub use self::secp256k1::Secp256k1;
 pub trait WeierstrassCurve:
     Clone + Debug + Default + Hash + Eq + PartialEq + Send + Sized + Sync
 {
+    /// Signatory's ID for this curve (same as the `signatory::ecdsa::curve` module name)
+    const ID: &'static str;
+
+    /// SECG identifier for this curve
+    const SECG_ID: &'static str;
+
+    /// Do we expect public keys for this curve to be represented as compressed
+    /// points as opposed to uncompressed?
+    // TODO: ensure we're handling this correctly, and perhaps find a better abstraction
+    const COMPRESSED_PUBLIC_KEY: bool;
+
     /// Size of a private scalar for this elliptic curve in bytes
     type PrivateScalarSize: ArrayLength<u8>;
 
@@ -26,9 +37,4 @@ pub trait WeierstrassCurve:
 
     /// Size of a compact, fixed-sized signature for this curve
     type FixedSignatureSize: ArrayLength<u8>;
-
-    /// Do we expect public keys for this curve to be represented as compressed
-    /// points as opposed to uncompressed?
-    // TODO: ensure we're handling this correctly, and perhaps find a better abstraction
-    const COMPRESSED_PUBLIC_KEY: bool;
 }

--- a/src/ecdsa/curve/nistp256/mod.rs
+++ b/src/ecdsa/curve/nistp256/mod.rs
@@ -29,6 +29,15 @@ pub use self::test_vectors::SHA256_FIXED_SIZE_TEST_VECTORS;
 pub struct NISTP256;
 
 impl WeierstrassCurve for NISTP256 {
+    /// Signatory's ID for this curve
+    const ID: &'static str = "nistp256";
+
+    /// SECG identifier for this curve
+    const SECG_ID: &'static str = "secp256r1";
+
+    /// We expect uncompressed public keys with P-256
+    const COMPRESSED_PUBLIC_KEY: bool = false;
+
     /// Random 256-bit (32-byte) private scalar
     type PrivateScalarSize = U32;
 
@@ -41,9 +50,6 @@ impl WeierstrassCurve for NISTP256 {
 
     /// Concatenated `r || s` values (32-bytes each)
     type FixedSignatureSize = U64;
-
-    /// We expect uncompressed public keys with P-256
-    const COMPRESSED_PUBLIC_KEY: bool = false;
 }
 
 /// NIST P-256 public key

--- a/src/ecdsa/curve/secp256k1/mod.rs
+++ b/src/ecdsa/curve/secp256k1/mod.rs
@@ -20,6 +20,15 @@ pub use self::test_vectors::SHA256_FIXED_SIZE_TEST_VECTORS;
 pub struct Secp256k1;
 
 impl WeierstrassCurve for Secp256k1 {
+    /// Signatory's ID for this curve
+    const ID: &'static str = "secp256k1";
+
+    /// SECG identifier for this curve
+    const SECG_ID: &'static str = "secp256k1";
+
+    /// We expect compressed public keys with secp256k1
+    const COMPRESSED_PUBLIC_KEY: bool = true;
+
     /// Random 256-bit (32-byte) private scalar
     type PrivateScalarSize = U32;
 
@@ -35,9 +44,6 @@ impl WeierstrassCurve for Secp256k1 {
 
     /// Concatenated `r || s` values (32-bytes each)
     type FixedSignatureSize = U64;
-
-    /// We expect compressed public keys with secp256k1
-    const COMPRESSED_PUBLIC_KEY: bool = true;
 }
 
 /// secp256k1 public key

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -16,10 +16,12 @@ mod test_macros;
 #[cfg(feature = "test-vectors")]
 mod test_vectors;
 
-pub use self::public_key::{PublicKey, PUBLIC_KEY_SIZE};
-pub use self::seed::{Seed, SEED_SIZE};
-pub use self::signature::{Signature, SIGNATURE_SIZE};
-pub use self::signer::{FromSeed, Signer};
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::TEST_VECTORS;
-pub use self::verifier::{DefaultVerifier, Verifier};
+pub use self::{
+    public_key::{PublicKey, PUBLIC_KEY_SIZE},
+    seed::{Seed, SEED_SIZE},
+    signature::{Signature, SIGNATURE_SIZE},
+    signer::*,
+    verifier::*,
+};

--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -2,6 +2,13 @@
 
 use core::fmt;
 
+#[cfg(
+    any(
+        feature = "dalek-provider",
+        feature = "ring-provider",
+        feature = "sodiumoxide-provider"
+    )
+)]
 use super::{DefaultVerifier, Signature, Verifier};
 use error::Error;
 use util::fmt_colon_delimited_hex;
@@ -45,6 +52,13 @@ impl PublicKey {
     }
 
     /// Verify a signature using this key
+    #[cfg(
+        any(
+            feature = "dalek-provider",
+            feature = "ring-provider",
+            feature = "sodiumoxide-provider"
+        )
+    )]
     pub fn verify(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
         DefaultVerifier::verify(self, msg, signature)
     }

--- a/src/ed25519/verifier.rs
+++ b/src/ed25519/verifier.rs
@@ -5,6 +5,15 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 
+use super::{PublicKey, Signature};
+use error::Error;
+
+/// Verifier for Ed25519 signatures
+pub trait Verifier: Clone + Debug + Hash + Eq + PartialEq + Send + Sync {
+    /// Verify an Ed25519 signature against the given public key
+    fn verify(key: &PublicKey, msg: &[u8], signature: &Signature) -> Result<(), Error>;
+}
+
 #[cfg(feature = "dalek-provider")]
 pub use providers::dalek::Ed25519Verifier as DefaultVerifier;
 
@@ -19,36 +28,3 @@ pub use providers::ring::Ed25519Verifier as DefaultVerifier;
     )
 )]
 pub use providers::sodiumoxide::Ed25519Verifier as DefaultVerifier;
-
-use super::{PublicKey, Signature};
-use error::Error;
-
-/// Verifier for Ed25519 signatures
-pub trait Verifier: Clone + Debug + Hash + Eq + PartialEq + Send + Sync {
-    /// Verify an Ed25519 signature against the given public key
-    fn verify(key: &PublicKey, msg: &[u8], signature: &Signature) -> Result<(), Error>;
-}
-
-/// A panicking default verifier if no providers have been selected
-#[cfg(
-    all(
-        not(feature = "dalek-provider"),
-        not(feature = "ring-provider"),
-        not(feature = "sodiumoxide-provider")
-    )
-)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct DefaultVerifier {}
-
-#[cfg(
-    all(
-        not(feature = "dalek-provider"),
-        not(feature = "ring-provider"),
-        not(feature = "sodiumoxide-provider")
-    )
-)]
-impl Verifier for DefaultVerifier {
-    fn verify(_key: &PublicKey, _msg: &[u8], _signature: &Signature) -> Result<(), Error> {
-        panic!("no Ed25519 providers available");
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ extern crate sodiumoxide;
 #[cfg(feature = "ring-provider")]
 extern crate untrusted;
 #[cfg(feature = "yubihsm-provider")]
-extern crate yubihsm;
+extern crate yubihsm as yubihsm_crate;
 
 #[macro_use]
 mod error;

--- a/src/providers/dalek/mod.rs
+++ b/src/providers/dalek/mod.rs
@@ -6,8 +6,6 @@
 //! When the "nightly" feature is enabled, ed25519-dalek should provide the
 //! best performance (on x86-64 at least) of the available Ed25519 backends
 //! for both signing and signature verification.
-//!
-//! This provider is enabled by default.
 
 mod ed25519;
 

--- a/src/providers/ring/ecdsa.rs
+++ b/src/providers/ring/ecdsa.rs
@@ -91,7 +91,7 @@ impl Signer<NISTP256> for P256DERSigner {
 }
 
 impl SHA256DERSigner<NISTP256> for P256DERSigner {
-    /// Compute an ASN.1 DER-encoded signature of the given 32-byte message
+    /// Compute an ASN.1 DER-encoded signature of the given message
     fn sign_sha256_der(&self, msg: &[u8]) -> Result<DERSignature<NISTP256>, Error> {
         DERSignature::from_bytes(self.0.sign(msg)?)
     }
@@ -123,7 +123,7 @@ impl Signer<NISTP256> for P256FixedSigner {
 }
 
 impl SHA256FixedSigner<NISTP256> for P256FixedSigner {
-    /// Compute a compact, fixed-sized signature of the given 32-byte message
+    /// Compute a compact, fixed-sized signature of the given message
     fn sign_sha256_fixed(&self, msg: &[u8]) -> Result<FixedSignature<NISTP256>, Error> {
         FixedSignature::from_bytes(self.0.sign(msg)?)
     }

--- a/src/providers/ring/mod.rs
+++ b/src/providers/ring/mod.rs
@@ -1,4 +1,4 @@
-//! *ring* provider: supports Ed25519 signing and verification
+//! *ring* provider: supports ECDSA (P-256) and Ed25519 signing and verification
 //!
 //! A popular and well-maintained Rust cryptography with wide support for many
 //! modern cryptographic algorithms.

--- a/src/providers/secp256k1/ecdsa.rs
+++ b/src/providers/secp256k1/ecdsa.rs
@@ -43,7 +43,7 @@ impl Signer<Secp256k1> for ECDSASigner {
 }
 
 impl RawDigestDERSigner<Secp256k1> for ECDSASigner {
-    /// Compute an ASN.1 DER-encoded signature of the given 32-byte message
+    /// Compute an ASN.1 DER-encoded signature of the given 32-byte SHA-256 digest
     fn sign_digest_der(&self, msg: &GenericArray<u8, U32>) -> Result<DERSignature, Error> {
         let m = Message::from_slice(msg.as_slice()).unwrap();
         match SECP256K1_ENGINE.sign(&m, &self.0) {
@@ -54,7 +54,7 @@ impl RawDigestDERSigner<Secp256k1> for ECDSASigner {
 }
 
 impl RawDigestFixedSigner<Secp256k1> for ECDSASigner {
-    /// Compute a compact, fixed-sized signature of the given 32-byte message
+    /// Compute a compact, fixed-sized signature of the given 32-byte SHA-256 digest
     fn sign_digest_fixed(&self, msg: &GenericArray<u8, U32>) -> Result<FixedSignature, Error> {
         let m = Message::from_slice(msg.as_slice()).unwrap();
         match SECP256K1_ENGINE.sign(&m, &self.0) {

--- a/src/providers/yubihsm/ecdsa.rs
+++ b/src/providers/yubihsm/ecdsa.rs
@@ -1,0 +1,290 @@
+//! ECDSA provider for the YubiHSM2 crate (supporting NIST P-256 and secp256k1)
+
+use generic_array::typenum::{U32, Unsigned};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, Mutex},
+};
+use yubihsm_crate;
+
+use super::{KeyId, Session};
+use ecdsa::{curve::WeierstrassCurve, signer::*, DERSignature, PublicKey};
+use error::Error;
+
+/// ECDSA signature provider for yubihsm-client
+pub struct ECDSASigner<Curve, Connector = yubihsm_crate::HttpConnector>
+where
+    Curve: WeierstrassCurve,
+    Connector: yubihsm_crate::Connector,
+{
+    /// Session with the YubiHSM
+    session: Arc<Mutex<yubihsm_crate::Session<Connector>>>,
+
+    /// ID of an ECDSA key to perform signatures with
+    signing_key_id: KeyId,
+
+    /// Placeholder for elliptic curve type
+    curve: PhantomData<Curve>,
+}
+
+impl<Curve> ECDSASigner<Curve, yubihsm_crate::HttpConnector>
+where
+    Curve: WeierstrassCurve,
+{
+    /// Create a new YubiHSM-backed ECDSA signer
+    pub(crate) fn new(session: &Session, signing_key_id: KeyId) -> Result<Self, Error> {
+        let signer = Self {
+            session: session.0.clone(),
+            signing_key_id,
+            curve: PhantomData,
+        };
+
+        // Ensure the signing_key_id slot contains a valid ECDSA public key
+        signer.public_key()?;
+
+        Ok(signer)
+    }
+}
+
+impl<Curve, Connector> ECDSASigner<Curve, Connector>
+where
+    Curve: WeierstrassCurve,
+    Connector: yubihsm_crate::Connector,
+{
+    /// Get the expected `yubihsm::AsymmetricAlgorithm` for this `Curve`
+    fn asymmetric_algorithm() -> Option<yubihsm_crate::AsymmetricAlgorithm> {
+        match Curve::ID {
+            "nistp256" => Some(yubihsm_crate::AsymmetricAlgorithm::EC_P256),
+            "secp256k1" => Some(yubihsm_crate::AsymmetricAlgorithm::EC_K256),
+            _ => None,
+        }
+    }
+}
+
+impl<Curve, Connector> Signer<Curve> for ECDSASigner<Curve, Connector>
+where
+    Curve: WeierstrassCurve,
+    Connector: yubihsm_crate::Connector,
+{
+    /// Obtain the public key which identifies this signer
+    fn public_key(&self) -> Result<PublicKey<Curve>, Error> {
+        let mut session = self.session.lock().unwrap();
+
+        let pubkey = yubihsm_crate::get_pubkey(&mut session, self.signing_key_id)
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        if Some(pubkey.algorithm) != Self::asymmetric_algorithm() {
+            fail!(
+                KeyInvalid,
+                "expected a {} key, got: {:?}",
+                Curve::ID,
+                pubkey.algorithm
+            );
+        }
+
+        Ok(PublicKey::from_bytes(pubkey.as_ref()).unwrap())
+    }
+}
+
+// TODO: figure out how to keep the concrete MockConnector type from leaking out
+// The MockHSM implementation of ECDSA does some odd workarounds for the *ring*
+// API since it's slightly incompatible with the API provided by the MockHSM
+// See: https://github.com/briansmith/ring/issues/253
+#[cfg(not(feature = "yubihsm-mockhsm"))]
+impl<Curve, Connector> SHA256DERSigner<Curve> for ECDSASigner<Curve, Connector>
+where
+    Curve: WeierstrassCurve<PrivateScalarSize = U32>,
+    Connector: yubihsm_crate::Connector,
+{
+    /// Compute an ASN.1 DER-encoded signature of the given message
+    fn sign_sha256_der(&self, msg: &[u8]) -> Result<DERSignature<Curve>, Error> {
+        let mut session = self.session.lock().unwrap();
+
+        let signature = yubihsm_crate::sign_ecdsa_sha256(&mut session, self.signing_key_id, msg)
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        let length = signature.as_ref().len();
+
+        if length > Curve::DERSignatureMaxSize::to_usize()
+            || length <= Curve::FixedSignatureSize::to_usize()
+        {
+            fail!(
+                ProviderError,
+                "unexpected signature size for {}: {}",
+                Curve::ID,
+                length
+            );
+        }
+
+        DERSignature::from_bytes(signature)
+    }
+}
+
+// TODO: figure out how to keep the concrete MockConnector type from leaking out (see above)
+#[cfg(feature = "yubihsm-mockhsm")]
+impl<Curve> SHA256DERSigner<Curve> for ECDSASigner<Curve, yubihsm_crate::mockhsm::MockConnector>
+where
+    Curve: WeierstrassCurve<PrivateScalarSize = U32>,
+{
+    /// Compute an ASN.1 DER-encoded signature of the given message
+    fn sign_sha256_der(&self, msg: &[u8]) -> Result<DERSignature<Curve>, Error> {
+        let mut session = self.session.lock().unwrap();
+
+        let signature = yubihsm_crate::sign_ecdsa_sha256(&mut session, self.signing_key_id, msg)
+            .map_err(|e| err!(ProviderError, "{}", e))?;
+
+        let length = signature.as_ref().len();
+
+        if length > Curve::DERSignatureMaxSize::to_usize()
+            || length <= Curve::FixedSignatureSize::to_usize()
+        {
+            fail!(
+                ProviderError,
+                "unexpected signature size for {}: {}",
+                Curve::ID,
+                length
+            );
+        }
+
+        DERSignature::from_bytes(signature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: fix secp256k1
+    #![allow(unused_imports)]
+
+    #[cfg(feature = "ring-provider")]
+    use providers::ring;
+    #[cfg(feature = "secp256k1-provider")]
+    use providers::secp256k1;
+    use std::marker::PhantomData;
+    use std::sync::{Arc, Mutex};
+    use yubihsm_crate;
+
+    use super::{ECDSASigner, KeyId, Signer};
+    use ecdsa::{
+        curve::{NISTP256, Secp256k1, WeierstrassCurve},
+        signer::SHA256DERSigner,
+        verifier::SHA256DERVerifier,
+    };
+
+    /// Default authentication key identifier
+    const DEFAULT_AUTH_KEY_ID: KeyId = 1;
+
+    /// Domain IDs for test key
+    const TEST_SIGNING_KEY_DOMAINS: yubihsm_crate::Domain = yubihsm_crate::Domain::DOM1;
+
+    /// Capability for test key
+    const TEST_SIGNING_KEY_CAPABILITIES: yubihsm_crate::Capability =
+        yubihsm_crate::Capability::ASYMMETRIC_SIGN_ECDSA;
+
+    /// Label for test key
+    const TEST_SIGNING_KEY_LABEL: &str = "Signatory test key";
+
+    /// Example message to sign
+    const TEST_MESSAGE: &[u8] =
+        b"The Elliptic Curve Digital Signature Algorithm (ECDSA) is a variant of the \
+          Digital Signature Algorithm (DSA) which uses elliptic curve cryptography.";
+
+    #[cfg(not(feature = "yubihsm-mockhsm"))]
+    type ConnectorType = yubihsm_crate::HttpConnector;
+
+    #[cfg(feature = "yubihsm-mockhsm")]
+    type ConnectorType = yubihsm_crate::mockhsm::MockConnector;
+
+    /// Create the signer for this test
+    fn create_signer<Curve>(key_id: KeyId) -> ECDSASigner<Curve, ConnectorType>
+    where
+        Curve: WeierstrassCurve,
+    {
+        #[cfg(not(feature = "yubihsm-mockhsm"))]
+        let session = Arc::new(Mutex::new(
+            yubihsm_crate::Session::create(
+                Default::default(),
+                DEFAULT_AUTH_KEY_ID,
+                yubihsm_crate::AuthKey::default(),
+                true,
+            ).unwrap_or_else(|err| panic!("error creating session: {}", err)),
+        ));
+
+        #[cfg(feature = "yubihsm-mockhsm")]
+        let session = Arc::new(Mutex::new(
+            yubihsm_crate::mockhsm::MockHSM::new()
+                .create_session(DEFAULT_AUTH_KEY_ID, yubihsm_crate::AuthKey::default())
+                .unwrap_or_else(|err| panic!("error creating session: {:?}", err)),
+        ));
+
+        let signer = ECDSASigner {
+            session,
+            signing_key_id: key_id,
+            curve: PhantomData,
+        };
+
+        create_yubihsm_key(&signer, key_id);
+        signer
+    }
+    /// Create the key on the YubiHSM to use for this test
+    fn create_yubihsm_key<Curve>(signer: &ECDSASigner<Curve, ConnectorType>, key_id: KeyId)
+    where
+        Curve: WeierstrassCurve,
+    {
+        let mut s = signer.session.lock().unwrap();
+
+        // Delete the key in TEST_KEY_ID slot it exists
+        // Ignore errors since the object may not exist yet
+        let _ =
+            yubihsm_crate::delete_object(&mut s, key_id, yubihsm_crate::ObjectType::AsymmetricKey);
+
+        // Create a new key for testing
+        yubihsm_crate::generate_asymmetric_key(
+            &mut s,
+            key_id,
+            TEST_SIGNING_KEY_LABEL.into(),
+            TEST_SIGNING_KEY_DOMAINS,
+            TEST_SIGNING_KEY_CAPABILITIES,
+            ECDSASigner::<Curve>::asymmetric_algorithm().unwrap(),
+        ).unwrap();
+    }
+
+    // We need *ring* to verify NIST P-256 ECDSA signatures
+    #[cfg(feature = "ring-provider")]
+    #[test]
+    fn ecdsa_nistp256_sign_test() {
+        let signer = create_signer::<NISTP256>(100);
+
+        let public_key = signer.public_key().unwrap();
+        let signature = signer.sign_sha256_der(TEST_MESSAGE).unwrap();
+
+        assert!(
+            ring::P256DERVerifier::verify_sha256_der_signature(
+                &public_key,
+                TEST_MESSAGE,
+                &signature
+            ).is_ok()
+        );
+    }
+
+    // We need secp256k1 to verify secp256k1 ECDSA signatures.
+    // The MockHSM does not presently support secp256k1
+    // TODO: completely refactor our handling of compressed vs uncompressed keys to get this working
+    //    #[cfg(
+    //        all(
+    //            feature = "secp256k1-provider",
+    //            not(feature = "yubihsm-mockhsm")
+    //        )
+    //    )]
+    //    #[test]
+    //    fn ecdsa_secp256k1_sign_test() {
+    //        let signer = create_signer::<Secp256k1>(101);
+    //
+    //        let public_key = signer.public_key().unwrap();
+    //        let signature = signer.sign_sha256_der(TEST_MESSAGE).unwrap();
+    //
+    //        assert!(
+    //            secp256k1::ECDSAVerifier::verify_sha256_der_signature(&public_key, TEST_MESSAGE, &signature)
+    //                .is_ok()
+    //        );
+    //    }
+}

--- a/src/providers/yubihsm/mod.rs
+++ b/src/providers/yubihsm/mod.rs
@@ -1,27 +1,26 @@
-//! yubihsm-rs provider: supports Ed25519 signing
+//! yubihsm-rs provider: supports ECDSA (P-256, secp256k1) and Ed25519 signing
 //!
 //! `YubiHSM2` devices are relatively inexpensive hardware security modules
-//! (HSMs) which natively implement the Ed25519 digital signature algorithm.
-//!
-//! This provider enables performing Ed25519 signatures with a hardware-backed
-//! signature key.
+//! (HSMs) which natively implement many cryptographic primitives including
+//! ECDSA and Ed25519, both of which are supported by this adapter.
 
 use std::sync::{Arc, Mutex};
-pub use yubihsm::connector::HttpConfig as Config;
-use yubihsm::AuthKey;
-use yubihsm::Session as YubiHSMSession;
-pub use yubihsm::AUTH_KEY_SIZE;
+use yubihsm_crate;
+pub use yubihsm_crate::connector::HttpConfig as Config;
 
+mod ecdsa;
 mod ed25519;
 
+use self::ecdsa::ECDSASigner;
 use self::ed25519::Ed25519Signer;
+use ecdsa::curve::WeierstrassCurve;
 use error::Error;
 
 /// Identifiers for keys in the `YubiHSM`
 pub type KeyId = u16;
 
 /// End-to-end encrypted session with the `YubiHSM`
-pub struct Session(Arc<Mutex<YubiHSMSession>>);
+pub struct Session(Arc<Mutex<yubihsm_crate::Session>>);
 
 impl Session {
     /// Create a new YubiHSM session from the given password
@@ -30,23 +29,60 @@ impl Session {
         auth_key_id: KeyId,
         password: &str,
     ) -> Result<Self, Error> {
-        Self::new(
-            config,
-            auth_key_id,
-            AuthKey::derive_from_password(password.as_bytes()),
-        )
+        let auth_key = yubihsm_crate::AuthKey::derive_from_password(password.as_bytes());
+
+        Self::new(config, auth_key_id, auth_key)
     }
 
     /// Create a new session with the YubiHSM
-    pub fn new<K: Into<AuthKey>>(
+    pub fn new<K: Into<yubihsm_crate::AuthKey>>(
         config: Config,
         auth_key_id: KeyId,
         auth_key: K,
     ) -> Result<Self, Error> {
-        let session = YubiHSMSession::create(config, auth_key_id, auth_key.into(), true)
+        let session = yubihsm_crate::Session::create(config, auth_key_id, auth_key.into(), true)
             .map_err(|e| err!(ProviderError, "{}", e))?;
 
         Ok(Session(Arc::new(Mutex::new(session))))
+    }
+
+    /// Create an ECDSA signer which uses this session. You will need to supply
+    /// an elliptic curve to use when creating a signer:
+    ///
+    /// ```rust,ignore
+    /// use signatory::ecdsa::{curve::NISTP256, signer::SHA256DERSigner};
+    /// use signatory::providers::yubihsm;
+    ///
+    /// let session = yubihsm::Session::create_from_password(
+    ///     yubihsm::Config::default(),
+    ///     1,
+    ///     "password"
+    /// ).unwrap();
+    ///
+    /// // Note: You'll need to create a NIST P-256 key in slot `123` first.
+    /// // Run the following from yubihsm-shell:
+    /// // `generate asymmetric 0 123 p256_test_key 1 asymmetric_sign_ecdsa ecp256`
+    /// let key_id = 123;
+    ///
+    /// // This will return an error unless there is already a NIST P-256 key
+    /// // in slot 123
+    /// let signer = session.ecdsa_signer::<NISTP256>(key_id).unwrap();
+    ///
+    /// let message = b"Hello, world!";
+    /// let signature = signer.sign_sha256_der(message).unwrap();
+    /// ```
+    ///
+    /// Supported elliptic curves are:
+    ///
+    /// * `signatory::ecdsa::curve::NISTP256`: NIST P-256 elliptic curve,
+    ///   a.k.a. prime256v1 or secp256r1
+    /// * `signatory::ecdsa::curve::Secp256k1`: secp256k1 elliptic curve
+    ///   (used by Bitcoin)
+    pub fn ecdsa_signer<C>(&self, signing_key_id: KeyId) -> Result<ECDSASigner<C>, Error>
+    where
+        C: WeierstrassCurve,
+    {
+        ECDSASigner::new(self, signing_key_id)
     }
 
     /// Create an Ed25519 signer which uses this session


### PR DESCRIPTION
This presently only works with NIST P-256. It's implemented generically, but getting secp256k1 will require some refactoring of the way public keys are handled.

Tested live against a YubiHSM2 and confirmed working, in addition to supporting testing against the MockHSM.