### PR TITLE
ECDSA DER signature parsing and serialization

### DIFF
--- a/src/asn1.rs
+++ b/src/asn1.rs
@@ -1,0 +1,24 @@
+//! Abstract Syntax Notation One (ASN.1) support.
+//! Presently specialized for Distinguished Encoding Rules (DER)
+
+// TODO: this code could probably benefit from some refactoring
+
+/// ASN.1 types
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Type {
+    /// ASN.1 `INTEGER`
+    Integer,
+
+    /// ASN.1 `SEQUENCE`: lists of other elements
+    Sequence,
+}
+
+impl Type {
+    /// ASN.1 tag value for this type
+    pub fn tag(&self) -> u8 {
+        match self {
+            Type::Integer => 0x02,
+            Type::Sequence => 0x30,
+        }
+    }
+}

--- a/src/ecdsa/signature/der.rs
+++ b/src/ecdsa/signature/der.rs
@@ -7,6 +7,8 @@ use generic_array::GenericArray;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
+use super::fixed::FixedSignature;
+use asn1;
 use ecdsa::curve::WeierstrassCurve;
 use error::Error;
 use util::fmt_colon_delimited_hex;
@@ -44,24 +46,167 @@ impl<C: WeierstrassCurve> DERSignature<C> {
         let mut array = GenericArray::default();
         array.as_mut_slice()[..length].copy_from_slice(bytes.as_ref());
 
-        Ok(Self {
+        let result = Self {
             bytes: array,
             length,
             curve: PhantomData,
-        })
+        };
+
+        // Ensure result is well-formed ASN.1 DER
+        result.parse()?;
+
+        Ok(result)
     }
 
-    /// Obtain signature as a byte array reference
+    /// Borrow the ASN.1 DER-encoded ECDSA signature as a byte slice
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes.as_slice()[..self.length]
     }
 
-    /// Convert signature into a byte vector
+    /// Serialize ASN.1 DER-encoded ECDSA signature into a byte vector
     #[cfg(feature = "std")]
     #[inline]
     pub fn into_bytes(self) -> Vec<u8> {
         self.as_bytes().into()
+    }
+
+    /// Parse the ASN.1 DER-encoded ECDSA signature, returning the `r` and `s`
+    /// as byte slices.
+    fn parse(&self) -> Result<(&[u8], &[u8]), Error> {
+        // Signature format is a SEQUENCE of two INTEGER values. We
+        // support only integers of less than 127 bytes each (signed
+        // encoding) so the resulting raw signature will have length
+        // at most 254 bytes.
+        let bytes = self.as_bytes();
+
+        // First byte is SEQUENCE tag.
+        ensure!(
+            bytes[0] == asn1::Type::Sequence.tag(),
+            ParseError,
+            "ASN.1 error: expected first byte to be a SEQUENCE tag: {}",
+            bytes[0]
+        );
+
+        // The SEQUENCE length will be encoded over one or two bytes. We
+        // limit the total SEQUENCE contents to 255 bytes, because it
+        // makes things simpler; this is enough for subgroup orders up
+        // to 999 bits.
+        let mut seq_len = bytes[1] as usize;
+
+        let mut offset = if seq_len > 0x80 {
+            ensure!(
+                seq_len == 0x81,
+                ParseError,
+                "ASN.1 error: overlength signature: {}",
+                seq_len
+            );
+
+            seq_len = bytes[2] as usize;
+            ensure!(
+                seq_len == bytes.len().checked_sub(3).unwrap(),
+                ParseError,
+                "ASN.1 error: sequence length mismatch ({} vs {})",
+                seq_len,
+                bytes.len().checked_sub(3).unwrap()
+            );
+
+            3
+        } else {
+            ensure!(
+                seq_len == bytes.len().checked_sub(2).unwrap(),
+                ParseError,
+                "ASN.1 error: sequence length mismatch ({} vs {})",
+                seq_len,
+                bytes.len().checked_sub(2).unwrap()
+            );
+
+            2
+        };
+
+        // First INTEGER (r)
+        ensure!(
+            bytes[offset] == asn1::Type::Integer.tag(),
+            ParseError,
+            "ASN.1 error: expected INTEGER tag (0x02) for 'r' (got 0x{:x})",
+            bytes[offset]
+        );
+        offset = offset.checked_add(1).unwrap();
+
+        let der_r_len = bytes[offset] as usize;
+        offset = offset.checked_add(1).unwrap();
+
+        ensure!(
+            der_r_len < 0x80,
+            ParseError,
+            "ASN.1 error: unexpected length for INTEGER 'r': {}",
+            der_r_len
+        );
+
+        let mut r = &bytes[offset..offset.checked_add(der_r_len).unwrap()];
+        offset = offset.checked_add(der_r_len).unwrap();
+
+        // Second INTEGER (s)
+        ensure!(
+            offset.checked_add(2).unwrap() <= bytes.len(),
+            ParseError,
+            "ASN.1 error: unexpected length for INTEGER 's': {}",
+            bytes.len()
+        );
+
+        ensure!(
+            bytes[offset] == asn1::Type::Integer.tag(),
+            ParseError,
+            "ASN.1 error: expected INTEGER tag (0x02) for 's' (got 0x{:x})",
+            bytes[offset]
+        );
+
+        offset = offset.checked_add(1).unwrap();
+
+        let der_s_len = bytes[offset] as usize;
+        offset = offset.checked_add(1).unwrap();
+
+        ensure!(
+            der_s_len < 0x80 && der_s_len == bytes.len().checked_sub(offset).unwrap(),
+            ParseError,
+            "ASN.1 error: unexpected length: {}",
+            der_s_len
+        );
+
+        let mut s = &bytes[offset..];
+
+        let fixed_int_len = C::FixedSignatureSize::to_usize() >> 1;
+
+        // TODO: handle additional leading zeroes?
+        if r.len() > fixed_int_len {
+            ensure!(
+                r.len() == fixed_int_len.checked_add(1).unwrap(),
+                ParseError,
+                "ASN.1 error: overlong 'r'"
+            );
+            ensure!(
+                r[0] == 0,
+                ParseError,
+                "ASN.1 error: expected leading 0 on 'r'"
+            );
+            r = &r[1..];
+        }
+
+        if s.len() > fixed_int_len {
+            ensure!(
+                s.len() == fixed_int_len.checked_add(1).unwrap(),
+                ParseError,
+                "ASN.1 error: overlong 's'"
+            );
+            ensure!(
+                s[0] == 0,
+                ParseError,
+                "ASN.1 error: expected leading 0 on 's'"
+            );
+            s = &s[1..];
+        }
+
+        Ok((r, s))
     }
 }
 
@@ -76,5 +221,170 @@ impl<C: WeierstrassCurve> Debug for DERSignature<C> {
         write!(f, "signatory::ecdsa::DERSignature<{:?}>(", C::default())?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
         write!(f, ")")
+    }
+}
+
+impl<C: WeierstrassCurve> From<FixedSignature<C>> for DERSignature<C> {
+    /// Parse `r` and `s` values from a fixed-width signature and reserialize
+    /// them as ASN.1 DER.
+    fn from(fixed_signature: FixedSignature<C>) -> Self {
+        let fixed_bytes = fixed_signature.as_bytes();
+        let mut der_array = GenericArray::default();
+
+        let fixed_sig_len = C::FixedSignatureSize::to_usize();
+        let fixed_int_len = fixed_sig_len >> 1;
+
+        // Compute DER-encoded output lengths for the two integers
+        let der_r_len = asn1_int_length(&fixed_bytes[..fixed_int_len]);
+        let der_s_len = asn1_int_length(&fixed_bytes[fixed_int_len..]);
+
+        assert!(der_r_len <= 125 && der_s_len <= 125, "signature too big");
+
+        let seq_len = der_r_len.checked_add(der_s_len).unwrap();
+
+        let mut der_sig_len = seq_len.checked_add(2).unwrap();
+
+        {
+            let der_bytes = der_array.as_mut_slice();
+
+            // SEQUENCE header
+            der_bytes[0] = asn1::Type::Sequence.tag();
+
+            let mut der_offset = if seq_len >= 0x80 {
+                der_bytes[1] = 0x81;
+                der_bytes[2] = seq_len as u8;
+                der_sig_len = der_sig_len.checked_add(1).unwrap();
+                3usize
+            } else {
+                der_bytes[1] = seq_len as u8;
+                2usize
+            };
+
+            // First INTEGER (r)
+            let fixed_r_begin = if der_r_len > fixed_int_len {
+                0
+            } else {
+                fixed_int_len.checked_sub(der_r_len).unwrap()
+            };
+
+            asn1_int_serialize(
+                &mut der_bytes[der_offset..],
+                der_r_len,
+                &fixed_bytes[fixed_r_begin..fixed_r_begin.checked_add(fixed_int_len).unwrap()],
+                fixed_int_len,
+            );
+
+            der_offset = der_offset.checked_add(der_r_len).unwrap();
+
+            // Second INTEGER (s)
+            let fixed_s_begin = if der_s_len > fixed_int_len {
+                fixed_int_len
+            } else {
+                fixed_sig_len.checked_sub(der_s_len).unwrap()
+            };
+
+            asn1_int_serialize(
+                &mut der_bytes[der_offset..],
+                der_s_len,
+                &fixed_bytes[fixed_s_begin..fixed_s_begin.checked_add(fixed_int_len).unwrap()],
+                fixed_int_len,
+            );
+        }
+
+        let result = Self {
+            bytes: der_array,
+            length: der_sig_len,
+            curve: PhantomData,
+        };
+
+        // Double-check we produced an ASN.1 signature we can parse ourselves
+        #[cfg(debug_assertions)]
+        result.parse().unwrap();
+
+        result
+    }
+}
+
+impl<C: WeierstrassCurve> From<DERSignature<C>> for FixedSignature<C> {
+    fn from(der_signature: DERSignature<C>) -> FixedSignature<C> {
+        let mut bytes = GenericArray::default();
+        let (r, s) = der_signature.parse().unwrap();
+
+        bytes.as_mut_slice()[..r.len()].copy_from_slice(r);
+        bytes.as_mut_slice()[r.len()..].copy_from_slice(s);
+
+        FixedSignature::from(bytes)
+    }
+}
+
+/// Compute ASN.1 DER encoded length for the provided integer. The ASN.1
+/// encoding is signed, so its leading bit must have value 0; it must also be
+/// of minimal length (so leading bytes of value 0 must be removed, except if
+/// that would contradict the rule about the sign bit).
+pub(crate) fn asn1_int_length(x: &[u8]) -> usize {
+    // Account for the INTEGER tag and length data
+    let mut len = x.len().checked_add(2).unwrap();
+
+    // Add extra space for a leading zero
+    if x[0] >= 0x80 {
+        len = len.checked_add(1).unwrap();
+    }
+
+    len
+}
+
+/// Serialize an integer as ASN.1 DER. Panics if `der_out` is too small to
+/// contain the serialized integer.
+pub(crate) fn asn1_int_serialize(der_out: &mut [u8], der_len: usize, value: &[u8], h_len: usize) {
+    assert!(der_len <= 125, "oversized value");
+
+    der_out[0] = asn1::Type::Integer.tag();
+    der_out[1] = der_len.checked_sub(2).unwrap() as u8;
+
+    let mut offset = 2;
+
+    if der_len > h_len.checked_add(offset).unwrap() {
+        der_out[2] = 0x00;
+        offset = offset.checked_add(1).unwrap();
+    }
+
+    der_out[offset..der_len].copy_from_slice(value);
+}
+
+#[cfg(test)]
+#[allow(unused_imports)]
+mod tests {
+    use ecdsa::{
+        curve::nistp256::{DERSignature, FixedSignature, SHA256_FIXED_SIZE_TEST_VECTORS},
+        signer::{SHA256FixedSigner, Signer},
+        verifier::SHA256DERVerifier,
+    };
+    #[cfg(feature = "ring")]
+    use providers::ring::{P256DERVerifier, P256FixedSigner};
+
+    #[test]
+    fn test_fixed_to_der_signature_roundtrip() {
+        for vector in SHA256_FIXED_SIZE_TEST_VECTORS {
+            let fixed_signature = FixedSignature::from_bytes(&vector.sig).unwrap();
+
+            // Convert to DER and back
+            let der_signature = DERSignature::from(fixed_signature.clone());
+            let fixed_signature2 = FixedSignature::from(der_signature);
+
+            assert_eq!(fixed_signature, fixed_signature2);
+        }
+    }
+
+    #[cfg(feature = "ring")]
+    #[test]
+    fn test_fixed_to_asn1_transformed_signature_verifies() {
+        for vector in SHA256_FIXED_SIZE_TEST_VECTORS {
+            let signer = P256FixedSigner::from_test_vector(vector);
+            let public_key = signer.public_key().unwrap();
+
+            let der_signature = DERSignature::from(signer.sign_sha256_fixed(vector.msg).unwrap());
+            P256DERVerifier::verify_sha256_der_signature(&public_key, vector.msg, &der_signature)
+                .unwrap();
+        }
     }
 }

--- a/src/ecdsa/signature/fixed.rs
+++ b/src/ecdsa/signature/fixed.rs
@@ -33,10 +33,7 @@ impl<C: WeierstrassCurve> FixedSignature<C> {
             bytes.as_ref().len()
         );
 
-        Ok(Self {
-            bytes: GenericArray::clone_from_slice(bytes.as_ref()),
-            curve: PhantomData,
-        })
+        Ok(Self::from(GenericArray::clone_from_slice(bytes.as_ref())))
     }
 
     /// Obtain signature as a byte array reference
@@ -63,5 +60,14 @@ impl<C: WeierstrassCurve> Debug for FixedSignature<C> {
         write!(f, "signatory::ecdsa::FixedSignature<{:?}>(", C::default())?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
         write!(f, ")")
+    }
+}
+
+impl<C: WeierstrassCurve> From<GenericArray<u8, C::FixedSignatureSize>> for FixedSignature<C> {
+    fn from(bytes: GenericArray<u8, C::FixedSignatureSize>) -> Self {
+        Self {
+            bytes,
+            curve: PhantomData,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ extern crate yubihsm as yubihsm_crate;
 mod error;
 
 #[cfg(feature = "ecdsa")]
+pub(crate) mod asn1;
+#[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 #[cfg(feature = "ed25519")]
 #[macro_use]


### PR DESCRIPTION
Support for parsing and serializing ECDSA signatures as ASN.1 DER. Signatures are now parsed when loaded via `DERSignature::from_bytes`, and invalid signatures are rejected.

This allows FixedSignature and DERSignature to be converted from one form to another, which will allow unifying the "Fixed" and "DER" ECDSA traits for signers and verifiers (actual work deferred for another PR).

This implementation is heavily inspired by the `br_ecdsa_raw_to_asn1()` and `br_ecdsa_asn1_to_raw()` functions from BearSSL:

https://www.bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/ec/ecdsa_atr.c;h=3a11226e49446667136e5825d9a171649f01aced;hb=8ef7680081c61b486622f2d983c0d3d21e83caad
https://www.bearssl.org/gitweb/?p=BearSSL;a=blob;f=src/ec/ecdsa_rta.c;h=005c62c2dbb84a3aba4ab4e9a2610a8d9257dc02;hb=8ef7680081c61b486622f2d983c0d3d21e83caad

BearSSL's author Thomas Pornin has waived copyright claims on this code as a derivative work of his, so we consider this code licensed under the same license as Signatory.