### PR TITLE
signatory-yubihsm: Make ecdsa and ed25519 modules public

### DIFF
--- a/providers/signatory-yubihsm/src/lib.rs
+++ b/providers/signatory-yubihsm/src/lib.rs
@@ -27,9 +27,9 @@ pub use yubihsm::connector::HttpConfig as Config;
 mod error;
 
 #[cfg(feature = "ecdsa")]
-mod ecdsa;
+pub mod ecdsa;
 #[cfg(feature = "ed25519")]
-mod ed25519;
+pub mod ed25519;
 
 #[cfg(feature = "ecdsa")]
 use self::ecdsa::ECDSASigner;


### PR DESCRIPTION
Right now they're opaque to rustdoc