### PR TITLE
Extract 'from_pkcs8' into a trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = { version = "0.7", optional = true }
 default = ["std", "test-vectors"]
 ecdsa = ["generic-array"]
 ed25519 = ["clear_on_drop", "rand"]
+pkcs8 = ["clear_on_drop"]
 std = []
 test-vectors = []
 

--- a/providers/signatory-ring/Cargo.toml
+++ b/providers/signatory-ring/Cargo.toml
@@ -20,7 +20,7 @@ untrusted = "0.6"
 [dependencies.signatory]
 version = "0.7"
 default-features = false
-features = ["test-vectors"]
+features = ["pkcs8", "test-vectors"]
 path = "../.."
 
 [dev-dependencies]

--- a/providers/signatory-ring/benches/ecdsa.rs
+++ b/providers/signatory-ring/benches/ecdsa.rs
@@ -12,6 +12,7 @@ use signatory::{
     curve::nistp256,
     ecdsa::{signer::*, verifier::*, FixedSignature, PublicKey},
     generic_array::GenericArray,
+    pkcs8::FromPKCS8,
     test_vector::TestVector,
 };
 use signatory_ring::ecdsa::{P256Signer, P256Verifier};

--- a/providers/signatory-ring/src/ecdsa.rs
+++ b/providers/signatory-ring/src/ecdsa.rs
@@ -13,6 +13,7 @@ use signatory::{
     ecdsa::{signer::*, verifier::*, DERSignature, FixedSignature, PublicKey},
     error::Error,
     generic_array::{typenum::Unsigned, GenericArray},
+    pkcs8::FromPKCS8,
 };
 
 use untrusted::Input;
@@ -67,10 +68,10 @@ where
 /// NIST P-256 ECDSA signer which produces ASN.1 DER encoded signatures
 pub struct P256Signer(ECDSASigner<NISTP256>);
 
-impl P256Signer {
+impl FromPKCS8 for P256Signer {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
-    pub fn from_pkcs8(pkcs_bytes: &[u8]) -> Result<Self, Error> {
-        let signer = ECDSASigner::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs_bytes)?;
+    fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error> {
+        let signer = ECDSASigner::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)?;
         Ok(P256Signer(signer))
     }
 }
@@ -133,6 +134,7 @@ mod tests {
             DERSignature, FixedSignature, PublicKey, SHA256_FIXED_SIZE_TEST_VECTORS,
         },
         ecdsa::{signer::*, verifier::*},
+        pkcs8::FromPKCS8,
     };
 
     #[test]

--- a/providers/signatory-ring/src/ed25519.rs
+++ b/providers/signatory-ring/src/ed25519.rs
@@ -7,6 +7,7 @@ use untrusted;
 use signatory::{
     ed25519::{FromSeed, PublicKey, Seed, Signature, Signer, Verifier},
     error::{Error, ErrorKind},
+    pkcs8::FromPKCS8,
 };
 
 /// Ed25519 signature provider for *ring*
@@ -23,10 +24,10 @@ impl FromSeed for Ed25519Signer {
     }
 }
 
-impl Ed25519Signer {
+impl FromPKCS8 for Ed25519Signer {
     /// Create a new Ed25519Signer from a PKCS#8 encoded private key
-    pub fn from_pkcs8(bytes: &[u8]) -> Result<Self, Error> {
-        let keypair = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(bytes))
+    fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error> {
+        let keypair = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(pkcs8_bytes))
             .map_err(|_| err!(KeyInvalid, "invalid PKCS#8 private key"))?;
 
         Ok(Ed25519Signer(keypair))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ pub mod ecdsa;
 #[cfg(feature = "ed25519")]
 #[macro_use]
 pub mod ed25519;
+#[cfg(feature = "pkcs8")]
+pub mod pkcs8;
 #[cfg(feature = "test-vectors")]
 pub mod test_vector;
 mod util;

--- a/src/pkcs8.rs
+++ b/src/pkcs8.rs
@@ -1,0 +1,31 @@
+//! Support for the `PKCS#8` private key format described in [RFC 5208] and [RFC 5915]
+//!
+//! [RFC 5208]: https://tools.ietf.org/html/rfc5208
+//! [RFC 5915]: https://tools.ietf.org/html/rfc5915
+
+use clear_on_drop::clear::Clear;
+use error::Error;
+#[cfg(feature = "std")]
+use std::io::Read;
+
+/// Instantiate this type from a `PKCS#8` private key
+pub trait FromPKCS8
+where
+    Self: Sized,
+{
+    /// Load the given `PKCS#8`-encoded private key, returning `Self` or an
+    /// error if the given data couldn't be loaded
+    fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error>;
+
+    /// Read `PKCS#8` data from the given `std::io::Read`
+    #[cfg(feature = "std")]
+    fn read_pkcs8<R: Read>(mut reader: R) -> Result<Self, Error> {
+        let mut bytes = vec![];
+        reader
+            .read_to_end(&mut bytes)
+            .map_err(|e| err!(KeyInvalid, "error reading key: {}", e))?;
+        let result = Self::from_pkcs8(&bytes);
+        bytes.as_mut_slice().clear();
+        result
+    }
+}


### PR DESCRIPTION
Allows loading PKCS#8 keys from different providers that support the trait. Presently limited to *ring*.