### PR TITLE
Cargo.toml: Build all features on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,4 @@ debug-assertions = false
 codegen-units = 1
 
 [package.metadata.docs.rs]
-features = ["digest", "ecdsa", "ed25519", "sha2"]
+all-features = true


### PR DESCRIPTION
We're presently missing docs for the `pkcs8` feature