### PR TITLE
Represent IntPair's r/s values using &GenericArray

### DIFF
--- a/src/curve/mod.rs
+++ b/src/curve/mod.rs
@@ -20,8 +20,13 @@ pub trait WeierstrassCurve:
     /// Elliptic curve kind
     const CURVE_KIND: WeierstrassCurveKind;
 
-    /// Size of a private scalar for this elliptic curve in bytes
-    type PrivateScalarSize: ArrayLength<u8>;
+    // TODO: unify these sizes, either with `typenum` or after const generics
+    // hopefully make this kind of type-level arithmetic easy to do.
+
+    /// Size of an integer modulo p (i.e. the curve's order) when serialized
+    /// as octets (i.e. bytes). This also describes the size of an ECDSA
+    /// private key, as well as half the size of a fixed-width signature.
+    type ScalarSize: ArrayLength<u8>;
 
     /// Size of a compressed point for this curve in bytes when serialized
     /// using `Octet-String-to-Elliptic-Curve-Point` encoding defined in
@@ -105,4 +110,4 @@ impl WeierstrassCurveKind {
 
 /// Digest input type for a particular Weierstrass curve
 #[cfg(feature = "digest")]
-pub type CurveDigest<C> = GenericArray<u8, <C as WeierstrassCurve>::PrivateScalarSize>;
+pub type CurveDigest<C> = GenericArray<u8, <C as WeierstrassCurve>::ScalarSize>;

--- a/src/curve/nistp256/mod.rs
+++ b/src/curve/nistp256/mod.rs
@@ -33,7 +33,7 @@ impl WeierstrassCurve for NistP256 {
     const CURVE_KIND: WeierstrassCurveKind = WeierstrassCurveKind::NistP256;
 
     /// Random 256-bit (32-byte) private scalar
-    type PrivateScalarSize = U32;
+    type ScalarSize = U32;
 
     /// Size of a compressed elliptic curve point serialized using
     /// `Octet-String-to-Elliptic-Curve-Point` encoding

--- a/src/curve/secp256k1/mod.rs
+++ b/src/curve/secp256k1/mod.rs
@@ -24,7 +24,7 @@ impl WeierstrassCurve for Secp256k1 {
     const CURVE_KIND: WeierstrassCurveKind = WeierstrassCurveKind::Secp256k1;
 
     /// Random 256-bit (32-byte) private scalar
-    type PrivateScalarSize = U32;
+    type ScalarSize = U32;
 
     /// Size of a compressed elliptic curve point serialized using
     /// `Octet-String-to-Elliptic-Curve-Point` encoding

--- a/src/ecdsa/verifier/digest.rs
+++ b/src/ecdsa/verifier/digest.rs
@@ -11,7 +11,7 @@ use error::Error;
 pub trait DigestVerifier<C, D>: Clone + Debug + Eq + PartialEq + Send + Sync
 where
     C: WeierstrassCurve,
-    D: Digest<OutputSize = C::PrivateScalarSize> + Default,
+    D: Digest<OutputSize = C::ScalarSize> + Default,
 {
     /// Verify an ASN.1 DER-encoded ECDSA signature for a given pre-hashed
     /// message `Digest` using the given public key.
@@ -37,7 +37,7 @@ where
 impl<C, D, V> DigestVerifier<C, D> for V
 where
     C: WeierstrassCurve,
-    D: Digest<OutputSize = C::PrivateScalarSize> + Default,
+    D: Digest<OutputSize = C::ScalarSize> + Default,
     V: RawDigestVerifier<C>,
 {
     fn verify_digest_asn1_signature(

--- a/src/ecdsa/verifier/raw_digest.rs
+++ b/src/ecdsa/verifier/raw_digest.rs
@@ -15,7 +15,7 @@ where
     /// whose length matches the size of the curve's field.
     fn verify_raw_digest_asn1_signature(
         key: &PublicKey<C>,
-        digest: &GenericArray<u8, C::PrivateScalarSize>,
+        digest: &GenericArray<u8, C::ScalarSize>,
         signature: &Asn1Signature<C>,
     ) -> Result<(), Error> {
         Self::verify_raw_digest_fixed_signature(key, digest, &FixedSignature::from(signature))
@@ -25,7 +25,7 @@ where
     /// whose length matches the size of the curve's field.
     fn verify_raw_digest_fixed_signature(
         key: &PublicKey<C>,
-        digest: &GenericArray<u8, C::PrivateScalarSize>,
+        digest: &GenericArray<u8, C::ScalarSize>,
         signature: &FixedSignature<C>,
     ) -> Result<(), Error> {
         Self::verify_raw_digest_asn1_signature(key, digest, &Asn1Signature::from(signature))

--- a/src/ecdsa/verifier/sha2.rs
+++ b/src/ecdsa/verifier/sha2.rs
@@ -19,7 +19,7 @@ use error::Error;
 /// digest sizes. If you are interested in this, please open an issue.
 pub trait Sha256Verifier<C>: Clone + Debug + Eq + PartialEq + Send + Sync
 where
-    C: WeierstrassCurve<PrivateScalarSize = U32>,
+    C: WeierstrassCurve<ScalarSize = U32>,
 {
     /// Verify an ASN.1 DER-encoded ECDSA signature for a given message using
     /// the given public key.
@@ -45,7 +45,7 @@ where
 #[cfg(feature = "sha2")]
 impl<C, V> Sha256Verifier<C> for V
 where
-    C: WeierstrassCurve<PrivateScalarSize = U32>,
+    C: WeierstrassCurve<ScalarSize = U32>,
     V: DigestVerifier<C, Sha256>,
 {
     fn verify_sha256_asn1_signature(


### PR DESCRIPTION
Ensures sizes are always correct, and eliminates the need to use PhantomData for the WeierstrassCurve type.