### PR TITLE
encoding: Add encoding module with hex and Base64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
   build:
     docker:
       - image: iqlusion/rust-ci:20180729.2 # bump cache keys when modifying this
-    environment:
     steps:
       - checkout
       - restore_cache:
@@ -44,29 +43,29 @@ jobs:
             cargo --version
             cargo build --features=ed25519
       - run:
-          name: build (--no-default-features + ecdsa + ed25519)
+          name: build (encoding feature only)
           command: |
             rustc --version
             cargo --version
-            cargo build --no-default-features --features=ecdsa,ed25519
+            cargo build --features=encoding
       - run:
-          name: build (ecdsa + ed25519)
+          name: build (--no-default-features + ecdsa + ed25519 + encoding + pkcs8)
+          command: |
+            rustc --version
+            cargo --version
+            cargo build --no-default-features --features=ecdsa,ed25519,encoding,pkcs8
+      - run:
+          name: build (default features + ecdsa + ed25519)
           command: |
             rustc --version
             cargo --version
             cargo build --features=ecdsa,ed25519
       - run:
-          name: build (--all-features)
+          name: test (default features + ecdsa + ed25519)
           command: |
             rustc --version
             cargo --version
-            cargo build --all-features
-      - run:
-          name: test (--all-features)
-          command: |
-            rustc --version
-            cargo --version
-            cargo test --all-features
+            cargo test --features=ecdsa,ed25519
       - run:
           name: signatory-dalek crate
           command: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,14 @@ rand = { version = "0.5", optional = true }
 sha2 = { version = "0.7", optional = true }
 
 [features]
-default = ["std", "test-vectors"]
+alloc = []
+default = ["pkcs8", "std", "test-vectors"]
 ecdsa = ["generic-array"]
 ed25519 = ["clear_on_drop", "rand"]
-pkcs8 = ["clear_on_drop"]
-std = []
+encoding = ["clear_on_drop"]
+nightly = ["alloc", "clear_on_drop/nightly"]
+pkcs8 = ["encoding"]
+std = ["alloc"]
 test-vectors = []
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -73,3 +73,11 @@ Signatory is distributed under the terms of both the MIT license and the
 Apache License (Version 2.0).
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
+
+Constant-time(ish) Base64 and hex decoding implementations adapted from:
+
+<https://github.com/Sc00bz/ConstTimeEncoding/>
+
+Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com).
+Licensed under the terms of the MIT license. See [LICENSE-MIT](LICENSE-MIT)
+for details.

--- a/providers/signatory-dalek/benches/ed25519.rs
+++ b/providers/signatory-dalek/benches/ed25519.rs
@@ -20,7 +20,7 @@ use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
 const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from_seed(Seed::from_slice(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from_seed(Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("dalek: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())

--- a/providers/signatory-ring/benches/ecdsa.rs
+++ b/providers/signatory-ring/benches/ecdsa.rs
@@ -11,8 +11,8 @@ use criterion::Criterion;
 use signatory::{
     curve::nistp256::{self, FixedSignature},
     ecdsa::{verifier::*, PublicKey},
+    encoding::FromPkcs8,
     generic_array::GenericArray,
-    pkcs8::FromPkcs8,
     test_vector::TestVector,
     Signature,
 };

--- a/providers/signatory-ring/benches/ed25519.rs
+++ b/providers/signatory-ring/benches/ed25519.rs
@@ -19,7 +19,7 @@ use signatory_ring::ed25519::{Ed25519Signer, Ed25519Verifier};
 const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from_seed(Seed::from_slice(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from_seed(Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("ring: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())

--- a/providers/signatory-ring/src/ecdsa.rs
+++ b/providers/signatory-ring/src/ecdsa.rs
@@ -15,9 +15,9 @@ use signatory::{
     ecdsa::{
         verifier::*, Asn1Signature, EcdsaSignature, EcdsaSignatureKind, FixedSignature, PublicKey,
     },
+    encoding::FromPkcs8,
     error::Error,
     generic_array::{typenum::Unsigned, GenericArray},
-    pkcs8::FromPkcs8,
     PublicKeyed, Sha256Signer, Signature,
 };
 
@@ -168,7 +168,7 @@ mod tests {
             Asn1Signature, FixedSignature, PublicKey, SHA256_FIXED_SIZE_TEST_VECTORS,
         },
         ecdsa::verifier::*,
-        pkcs8::FromPkcs8,
+        encoding::FromPkcs8,
         PublicKeyed, Signature,
     };
 

--- a/providers/signatory-ring/src/ed25519.rs
+++ b/providers/signatory-ring/src/ed25519.rs
@@ -6,8 +6,8 @@ use untrusted;
 
 use signatory::{
     ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed, Verifier},
+    encoding::FromPkcs8,
     error::{Error, ErrorKind},
-    pkcs8::FromPkcs8,
     PublicKeyed, Signature, Signer,
 };
 

--- a/providers/signatory-secp256k1/src/lib.rs
+++ b/providers/signatory-secp256k1/src/lib.rs
@@ -63,7 +63,7 @@ impl PublicKeyed<PublicKey> for EcdsaSigner {
     /// Return the public key that corresponds to the private key for this signer
     fn public_key(&self) -> Result<PublicKey, Error> {
         let pk = secp256k1::key::PublicKey::from_secret_key(&SECP256K1_ENGINE, &self.0);
-        PublicKey::from_slice(&pk.serialize()[..])
+        PublicKey::from_bytes(&pk.serialize()[..])
     }
 }
 
@@ -179,7 +179,7 @@ mod tests {
     pub fn fixed_signature_vectors() {
         for vector in SHA256_FIXED_SIZE_TEST_VECTORS {
             let signer = EcdsaSigner::from_bytes(vector.sk).unwrap();
-            let public_key = PublicKey::from_slice(vector.pk).unwrap();
+            let public_key = PublicKey::from_bytes(vector.pk).unwrap();
             assert_eq!(signer.public_key().unwrap(), public_key);
 
             let signature: FixedSignature = signatory::sign_sha256(&signer, vector.msg).unwrap();

--- a/providers/signatory-sodiumoxide/benches/ed25519.rs
+++ b/providers/signatory-sodiumoxide/benches/ed25519.rs
@@ -20,7 +20,7 @@ use signatory_sodiumoxide::{Ed25519Signer, Ed25519Verifier};
 const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from_seed(Seed::from_slice(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from_seed(Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("sodiumoxide: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())

--- a/src/ecdsa/signature/pair.rs
+++ b/src/ecdsa/signature/pair.rs
@@ -13,8 +13,8 @@ use generic_array::{typenum::Unsigned, GenericArray};
 
 use super::asn1::Asn1Signature;
 use super::fixed::FixedSignature;
-use asn1;
 use curve::WeierstrassCurve;
+use encoding::asn1;
 use error::Error;
 use signature::Signature;
 

--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -2,7 +2,13 @@
 
 use core::fmt::{self, Debug};
 
+#[cfg(all(feature = "alloc", feature = "encoding"))]
+use encoding::Encode;
+#[cfg(feature = "encoding")]
+use encoding::{Decode, Encoding};
 use error::Error;
+#[allow(unused_imports)]
+use prelude::*;
 use util::fmt_colon_delimited_hex;
 use PublicKey as PublicKeyTrait;
 
@@ -14,6 +20,11 @@ pub const PUBLIC_KEY_SIZE: usize = 32;
 pub struct PublicKey(pub [u8; PUBLIC_KEY_SIZE]);
 
 impl PublicKey {
+    /// Create an Ed25519 public key from a 32-byte array
+    pub fn new(bytes: [u8; PUBLIC_KEY_SIZE]) -> Self {
+        PublicKey(bytes)
+    }
+
     /// Create an Ed25519 public key from its serialized (compressed Edwards-y) form
     pub fn from_bytes<B>(bytes: B) -> Result<Self, Error>
     where
@@ -57,6 +68,33 @@ impl Debug for PublicKey {
         write!(f, "signatory::ed25519::PublicKey(")?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
         write!(f, ")")
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl Decode for PublicKey {
+    /// Decode an Ed25519 seed from a byte slice with the given encoding (e.g. hex, Base64)
+    fn decode(encoded_key: &[u8], encoding: Encoding) -> Result<Self, Error> {
+        let mut decoded_key = [0u8; PUBLIC_KEY_SIZE];
+        let decoded_len = encoding.decode(encoded_key, &mut decoded_key)?;
+
+        ensure!(
+            decoded_len == PUBLIC_KEY_SIZE,
+            KeyInvalid,
+            "invalid {}-byte public key (expected {})",
+            decoded_len,
+            PUBLIC_KEY_SIZE
+        );
+
+        Ok(Self::new(decoded_key))
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "alloc"))]
+impl Encode for PublicKey {
+    /// Encode an Ed25519 seed with the given encoding (e.g. hex, Base64)
+    fn encode(&self, encoding: Encoding) -> Vec<u8> {
+        encoding.encode_vec(self.as_bytes())
     }
 }
 

--- a/src/ed25519/test_macros.rs
+++ b/src/ed25519/test_macros.rs
@@ -14,7 +14,7 @@ macro_rules! ed25519_tests {
         #[test]
         fn sign_rfc8032_test_vectors() {
             for vector in TEST_VECTORS {
-                let seed = Seed::from_slice(vector.sk).unwrap();
+                let seed = Seed::from_bytes(vector.sk).unwrap();
                 let mut signer = $signer::from_seed(seed);
                 assert_eq!(signer.sign(vector.msg).unwrap().as_ref(), vector.sig);
             }

--- a/src/encoding/asn1.rs
+++ b/src/encoding/asn1.rs
@@ -2,7 +2,7 @@
 //! Presently specialized for Distinguished Encoding Rules (DER)
 
 /// ASN.1 tags
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub(crate) enum Tag {
     /// ASN.1 `INTEGER`

--- a/src/encoding/base64.rs
+++ b/src/encoding/base64.rs
@@ -1,0 +1,264 @@
+//! Base64 encoder/decoder which avoids data-dependent branching
+//! (i.e. constant time-ish)
+
+// Adapted from this C++ implementation:
+//
+// <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/base64.cpp>
+//
+// Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use clear_on_drop::clear::Clear;
+use error::Error;
+
+/// Encode Base64  with branchless / secret-independent logic.
+/// Base64 character set: `[A-Z][a-z][0-9]+/`
+pub(crate) fn encode(src: &[u8], dst: &mut [u8]) -> usize {
+    let mut src_off: usize = 0;
+    let mut dst_off: usize = 0;
+    let mut src_len: usize = src.len();
+
+    while src_len >= 3 {
+        encode_3bytes(
+            &src[src_off..add!(src_off, 3)],
+            &mut dst[dst_off..add!(dst_off, 4)],
+        );
+
+        src_off = add!(src_off, 3);
+        dst_off = add!(dst_off, 4);
+        src_len = sub!(src_len, 3);
+    }
+
+    if src_len > 0 {
+        let mut tmp = [0u8; 3];
+        tmp[..src_len].copy_from_slice(&src[src_off..add!(src_off, src_len)]);
+
+        encode_3bytes(&tmp, &mut dst[dst_off..]);
+        dst[add!(dst_off, 3)] = b'=';
+
+        if src_len == 1 {
+            dst[add!(dst_off, 2)] = b'=';
+        }
+
+        dst_off = add!(dst_off, 4);
+        tmp.clear();
+    }
+
+    dst_off
+}
+
+/// Decode Base64 with branchless / secret-independent logic.
+/// Base64 character set: `[A-Z][a-z][0-9]+/`
+pub(crate) fn decode(src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+    let mut src_off: usize = 0;
+    let mut dst_off: usize = 0;
+    let mut src_len: usize = src.len();
+    let mut err: isize = 0;
+
+    while src_len > 4 {
+        err |= decode_3bytes(
+            &src[src_off..add!(src_off, 4)],
+            &mut dst[dst_off..add!(dst_off, 3)],
+        );
+
+        src_off = add!(src_off, 4);
+        dst_off = add!(dst_off, 3);
+        src_len = sub!(src_len, 4);
+    }
+
+    if src_len > 0 {
+        let mut i = 0;
+        let mut tmp_out = [0u8; 3];
+        let mut tmp_in = [b'A'; 4];
+
+        while i < src_len && src[add!(src_off, i)] != b'=' {
+            tmp_in[i] = src[add!(src_off, i)];
+            i = add!(i, 1);
+        }
+
+        if i < 2 {
+            err = 1;
+        }
+
+        src_len = sub!(i, 1);
+        err |= decode_3bytes(&tmp_in, &mut tmp_out);
+
+        dst[dst_off..add!(dst_off, src_len)].copy_from_slice(&tmp_out[..src_len]);
+        dst_off = add!(dst_off, sub!(i, 1));
+
+        tmp_out.clear();
+        tmp_in.clear();
+    }
+
+    if err == 0 {
+        Ok(dst_off)
+    } else {
+        fail!(ParseError, "error occurred while decoding");
+    }
+}
+
+//
+// Helper Functions
+//
+
+// Base64 character set:
+// [A-Z]      [a-z]      [0-9]      +     /
+// 0x41-0x5a, 0x61-0x7a, 0x30-0x39, 0x2b, 0x2f
+
+#[inline]
+fn encode_3bytes(src: &[u8], dst: &mut [u8]) {
+    let b0 = src[0] as isize;
+    let b1 = src[1] as isize;
+    let b2 = src[2] as isize;
+
+    dst[0] = encode_6bits(shr!(b0, 2));
+    dst[1] = encode_6bits((shl!(b0, 4) | shr!(b1, 4)) & 63);
+    dst[2] = encode_6bits((shl!(b1, 2) | shr!(b2, 6)) & 63);
+    dst[3] = encode_6bits(b2 & 63);
+}
+
+#[inline]
+fn encode_6bits(src: isize) -> u8 {
+    let mut diff: isize = 0x41;
+
+    // if (in > 25) diff += 0x61 - 0x41 - 26; // 6
+    diff = add!(diff, shr!(sub!(25isize, src), 8) & 6);
+
+    // if (in > 51) diff += 0x30 - 0x61 - 26; // -75
+    diff = sub!(diff, shr!(sub!(51isize, src), 8) & 75);
+
+    // if (in > 61) diff += 0x2b - 0x30 - 10; // -15
+    diff = sub!(diff, shr!(sub!(61isize, src), 8) & 15);
+
+    // if (in > 62) diff += 0x2f - 0x2b - 1; // 3
+    diff = add!(diff, shr!(sub!(62isize, src), 8) & 3);
+
+    add!(src, diff) as u8
+}
+
+#[inline]
+fn decode_3bytes(src: &[u8], dst: &mut [u8]) -> isize {
+    let c0 = decode_6bits(src[0]);
+    let c1 = decode_6bits(src[1]);
+    let c2 = decode_6bits(src[2]);
+    let c3 = decode_6bits(src[3]);
+
+    dst[0] = (shl!(c0, 2) | shr!(c1, 4)) as u8;
+    dst[1] = (shl!(c1, 4) | shr!(c2, 2)) as u8;
+    dst[2] = (shl!(c2, 6) | c3) as u8;
+
+    shr!(c0 | c1 | c2 | c3, 8) & 1
+}
+
+#[inline]
+fn decode_6bits(src: u8) -> isize {
+    let ch = src as isize;
+    let mut ret: isize = -1;
+
+    // if (ch > 0x40 && ch < 0x5b) ret += ch - 0x41 + 1; // -64
+    ret = add!(
+        ret,
+        shr!(sub!(0x40isize, ch) & sub!(ch, 0x5bisize), 8) & sub!(ch, 64isize)
+    );
+
+    // if (ch > 0x60 && ch < 0x7b) ret += ch - 0x61 + 26 + 1; // -70
+    ret = add!(
+        ret,
+        shr!(sub!(0x60isize, ch) & sub!(ch, 0x7bisize), 8) & sub!(ch, 70isize)
+    );
+
+    // if (ch > 0x2f && ch < 0x3a) ret += ch - 0x30 + 52 + 1; // 5
+    ret = add!(
+        ret,
+        shr!(sub!(0x2fisize, ch) & sub!(ch, 0x3aisize), 8) & add!(ch, 5isize)
+    );
+
+    // if (ch == 0x2b) ret += 62 + 1;
+    ret = add!(ret, shr!(sub!(0x2aisize, ch) & sub!(ch, 0x2cisize), 8) & 63);
+
+    // if (ch == 0x2f) ret += 63 + 1;
+    add!(ret, shr!(sub!(0x2eisize, ch) & sub!(ch, 0x30isize), 8) & 64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prelude::*;
+
+    /// Base64 test vectors
+    struct Base64Vector {
+        /// Raw bytes
+        raw: &'static [u8],
+
+        /// Hex encoded
+        base64: &'static [u8],
+    }
+
+    const BASE64_TEST_VECTORS: &[Base64Vector] = &[
+        Base64Vector {
+            raw: b"",
+            base64: b"",
+        },
+        Base64Vector {
+            raw: b"\0",
+            base64: b"AA==",
+        },
+        Base64Vector {
+            raw: b"***",
+            base64: b"Kioq",
+        },
+        Base64Vector {
+            raw: b"\x01\x02\x03\x04",
+            base64: b"AQIDBA==",
+        },
+        Base64Vector {
+            raw: b"\xAD\xAD\xAD\xAD\xAD",
+            base64: b"ra2tra0=",
+        },
+        Base64Vector {
+            raw: b"\xFF\xFF\xFF\xFF\xFF",
+            base64: b"//////8=",
+        },
+    ];
+
+    #[test]
+    fn encode_test_vectors() {
+        for vector in BASE64_TEST_VECTORS {
+            // 8 is the size of the largest encoded test vector
+            let mut out = [0u8; 8];
+            let out_len = encode(vector.raw, &mut out);
+            assert_eq!(vector.base64, &out[..out_len]);
+        }
+    }
+
+    #[test]
+    fn decode_test_vectors() {
+        for vector in BASE64_TEST_VECTORS {
+            // 5 is the size of the largest decoded test vector
+            let mut out = [0u8; 5];
+            println!(
+                "decoding: {:?}",
+                String::from_utf8(vector.base64.to_vec()).unwrap()
+            );
+            let out_len = decode(vector.base64, &mut out).unwrap();
+            assert_eq!(vector.raw, &out[..out_len]);
+        }
+    }
+}

--- a/src/encoding/decode.rs
+++ b/src/encoding/decode.rs
@@ -1,0 +1,37 @@
+#[cfg(feature = "std")]
+use clear_on_drop::ClearOnDrop;
+#[cfg(feature = "std")]
+use std::{fs::File, io::Read, path::Path};
+
+use super::Encoding;
+use error::Error;
+
+/// Decode objects from encoded data (e.g. hex, Base64). Uses constant time
+/// encoder/decoder implementations designed to avoid leaking private keys.
+pub trait Decode: Sized {
+    /// Decode the given byte slice using the provided `Encoding`, returning
+    /// the decoded value or a `Error`.
+    fn decode(encoded: &[u8], encoding: Encoding) -> Result<Self, Error>;
+
+    /// Decode the given string-alike type with the provided `Encoding`,
+    /// returning the decoded value or a `Error`.
+    fn decode_str<S: AsRef<str>>(encoded: S, encoding: Encoding) -> Result<Self, Error> {
+        Self::decode(encoded.as_ref().as_bytes(), encoding)
+    }
+
+    /// Decode the data read from the given `io::Read` type with the provided
+    /// `Encoding`, returning the decoded value or a `Error`.
+    #[cfg(feature = "std")]
+    fn decode_reader<R: Read>(reader: &mut R, encoding: Encoding) -> Result<Self, Error> {
+        let mut bytes = ClearOnDrop::new(vec![]);
+        reader.read_to_end(bytes.as_mut())?;
+        Self::decode(&bytes, encoding)
+    }
+
+    /// Read a file at the given path, decoding the data it contains using
+    /// the provided `Encoding`, returning the decoded value or a `Error`.
+    #[cfg(feature = "std")]
+    fn decode_file<P: AsRef<Path>>(self, path: P, encoding: Encoding) -> Result<Self, Error> {
+        Self::decode_reader(&mut File::open(path.as_ref())?, encoding)
+    }
+}

--- a/src/encoding/encode.rs
+++ b/src/encoding/encode.rs
@@ -1,0 +1,45 @@
+use clear_on_drop::ClearOnDrop;
+#[cfg(feature = "std")]
+use std::{fs::File, io::Write, path::Path};
+
+use super::Encoding;
+use error::Error;
+use prelude::*;
+
+/// Encode objects from bytes data (e.g. hex, Base64). Uses constant time
+/// encoder/encoder implementations designed to avoid leaking private keys.
+pub trait Encode: Sized {
+    /// Encode this object to a `Vec<u8>` using the provided `Encoding`, returning
+    /// the encoded value or a `Error`.
+    fn encode(&self, encoding: Encoding) -> Vec<u8>;
+
+    /// Encode the given string-alike type with the provided `Encoding`,
+    /// returning the encoded value or a `Error`.
+    ///
+    /// Panics if the supplied encoding does not result in a UTF-8 string,
+    /// i.e. `Encoding::Raw`
+    fn encode_to_string<S: AsRef<str>>(&self, encoding: Encoding) -> String {
+        String::from_utf8(self.encode(encoding)).unwrap()
+    }
+
+    /// Encode the data read to the given `io::Read` type with the provided
+    /// `Encoding`, returning the encoded value or a `Error`.
+    #[cfg(feature = "std")]
+    fn encode_to_writer<W: Write>(
+        &self,
+        writer: &mut W,
+        encoding: Encoding,
+    ) -> Result<usize, Error> {
+        let bytes = ClearOnDrop::new(self.encode(encoding));
+        Ok(writer.write(bytes.as_ref())?)
+    }
+
+    /// Read a file at the given path, decoding the data it contains using
+    /// the provided `Encoding`, returning the encoded value or a `Error`.
+    #[cfg(feature = "std")]
+    fn encode_to_file<P: AsRef<Path>>(&self, path: P, encoding: Encoding) -> Result<File, Error> {
+        let mut file = File::open(path.as_ref())?;
+        self.encode_to_writer(&mut file, encoding)?;
+        Ok(file)
+    }
+}

--- a/src/encoding/hex.rs
+++ b/src/encoding/hex.rs
@@ -1,0 +1,176 @@
+//! Hexadecimal encoder/decoder which avoids data-dependent branching
+//! (i.e. constant time-ish)
+
+// Adapted from this C++ implementation:
+//
+// <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/hex.cpp>
+//
+// Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use error::Error;
+
+/// Encode hexadecimal (lower case) with branchless / secret-independent logic
+pub(super) fn encode(src: &[u8], dst: &mut [u8]) -> usize {
+    for (i, src_byte) in src.iter().enumerate() {
+        let offset = mul!(i, 2);
+        dst[offset] = encode_nibble(shr!(src_byte, 4));
+        dst[add!(offset, 1)] = encode_nibble(src_byte & 0x0f);
+    }
+
+    mul!(src.len(), 2)
+}
+
+/// Decode hexadecimal (upper or lower case) with branchless / secret-independent logic
+pub(super) fn decode(src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+    let src_len = src.len();
+    let mut err: usize = 0;
+
+    if src_len == 0 {
+        return Ok(0);
+    } else if src_len & 1 != 0 {
+        fail!(ParseError, "invalid hex encoding (bad length)");
+    }
+
+    let dst_len = shr!(src_len, 1);
+
+    if dst_len > dst.len() {
+        fail!(ParseError, "input is too long");
+    }
+
+    for (i, dst_byte) in dst.iter_mut().enumerate().take(dst_len) {
+        let src_offset = mul!(i, 2);
+        let byte =
+            shl!(decode_nibble(src[src_offset]), 4) | decode_nibble(src[add!(src_offset, 1)]);
+        err |= shr!(byte, 8);
+        *dst_byte = byte as u8;
+    }
+
+    if err == 0 {
+        Ok(dst_len)
+    } else {
+        fail!(ParseError, "error occurred while decoding");
+    }
+}
+
+/// Decode a single nibble of hex
+#[inline]
+fn decode_nibble(src: u8) -> usize {
+    // 0-9  0x30-0x39
+    // A-F  0x41-0x46 or a-f  0x61-0x66
+    let mut byte = src as isize;
+    let mut ret: isize = -1;
+
+    // if (byte > 0x2f && byte < 0x3a) ret += byte - 0x30 + 1; // -47
+    ret = add!(
+        ret,
+        shr!((sub!(0x2fisize, byte) & sub!(byte, 0x3a)), 8) & sub!(byte, 47)
+    );
+
+    // case insensitive decode
+    byte |= 0x20;
+
+    // if (byte > 0x60 && byte < 0x67) ret += byte - 0x61 + 10 + 1; // -86
+    add!(
+        ret,
+        shr!(sub!(0x60isize, byte) & sub!(byte, 0x67), 8) & sub!(byte, 86)
+    ) as usize
+}
+
+/// Encode a single nibble of hex
+#[inline]
+fn encode_nibble(src: u8) -> u8 {
+    let mut ret: isize = src as isize;
+
+    // 0-9  0x30-0x39
+    // a-f  0x61-0x66
+    ret = add!(ret, 0x30);
+
+    // if (in > 0x39) in += 0x61 - 0x3a;
+    add!(ret, shr!(sub!(0x39isize, ret), 8) & sub!(0x61isize, 0x3a)) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use error::ErrorKind;
+
+    /// Hexadecimal test vectors
+    struct HexVector {
+        /// Raw bytes
+        raw: &'static [u8],
+
+        /// Hex encoded
+        hex: &'static [u8],
+    }
+
+    const HEX_TEST_VECTORS: &[HexVector] = &[
+        HexVector { raw: b"", hex: b"" },
+        HexVector {
+            raw: b"\0",
+            hex: b"00",
+        },
+        HexVector {
+            raw: b"***",
+            hex: b"2a2a2a",
+        },
+        HexVector {
+            raw: b"\x01\x02\x03\x04",
+            hex: b"01020304",
+        },
+        HexVector {
+            raw: b"\xAD\xAD\xAD\xAD\xAD",
+            hex: b"adadadadad",
+        },
+        HexVector {
+            raw: b"\xFF\xFF\xFF\xFF\xFF",
+            hex: b"ffffffffff",
+        },
+    ];
+
+    #[test]
+    fn encode_test_vectors() {
+        for vector in HEX_TEST_VECTORS {
+            // 10 is the size of the largest encoded test vector
+            let mut out = [0u8; 10];
+            let out_len = encode(vector.raw, &mut out);
+            assert_eq!(vector.hex, &out[..out_len]);
+        }
+    }
+
+    #[test]
+    fn decode_test_vectors() {
+        for vector in HEX_TEST_VECTORS {
+            // 5 is the size of the largest decoded test vector
+            let mut out = [0u8; 5];
+            let out_len = decode(vector.hex, &mut out).unwrap();
+            assert_eq!(vector.raw, &out[..out_len]);
+        }
+    }
+
+    #[test]
+    fn decode_odd_size_input() {
+        let mut out = [0u8; 3];
+        assert_eq!(
+            decode(b"12345", &mut out).err().unwrap().kind(),
+            ErrorKind::ParseError
+        )
+    }
+}

--- a/src/encoding/macros.rs
+++ b/src/encoding/macros.rs
@@ -1,0 +1,46 @@
+//! Macros for performing arithmetic which checks for overflow/underflow in
+//! in a more succinct manner
+
+#![allow(unused_macros)]
+
+/// Checked addition
+macro_rules! add {
+    ($a:expr, $b:expr) => {
+        $a.checked_add($b).expect("overflow")
+    };
+}
+
+/// Checked subtraction
+macro_rules! sub {
+    ($a:expr, $b:expr) => {
+        $a.checked_sub($b).expect("underflow")
+    };
+}
+
+/// Checked multiplication
+macro_rules! mul {
+    ($a:expr, $b:expr) => {
+        $a.checked_mul($b).expect("overflow")
+    };
+}
+
+/// Checked division
+macro_rules! div {
+    ($a:expr, $b:expr) => {
+        $a.checked_div($b).expect("overflow")
+    };
+}
+
+/// Checked right shift
+macro_rules! shr {
+    ($a:expr, $b:expr) => {
+        $a.checked_shr($b).expect("overflow")
+    };
+}
+
+/// Checked left shift
+macro_rules! shl {
+    ($a:expr, $b:expr) => {
+        $a.checked_shl($b).expect("overflow")
+    };
+}

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -1,0 +1,154 @@
+//! Support for encoding and decoding serialization formats (hex and Base64)
+//! with implementations that do not branch on potentially secret data, such
+//! as cryptographic keys.
+
+#[macro_use]
+mod macros;
+
+#[cfg(feature = "ecdsa")]
+pub(crate) mod asn1;
+mod base64;
+mod decode;
+#[cfg(feature = "alloc")]
+mod encode;
+mod hex;
+#[cfg(feature = "pkcs8")]
+mod pkcs8;
+
+pub use self::decode::Decode;
+#[cfg(feature = "alloc")]
+pub use self::encode::Encode;
+#[cfg(feature = "pkcs8")]
+pub use self::pkcs8::FromPkcs8;
+
+use error::Error;
+#[allow(unused_imports)]
+use prelude::*;
+
+/// Types of encodings natively supported by Signatory
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum Encoding {
+    /// Raw bytes
+    Raw,
+
+    /// Hexadecimal encoding
+    Hex,
+
+    /// Base64 (RFC 4648) encoding (no support for Base64uri, sorry)
+    Base64,
+}
+
+/// Decode input bytes to output bytes
+impl Encoding {
+    /// Encode the input with this encoding into to the given buffer.
+    /// Returns the size of the encoded output.
+    ///
+    /// Panics if the destination buffer is not sufficiently large to hold
+    /// the encoded output.
+    pub fn encode(self, src: &[u8], dst: &mut [u8]) -> usize {
+        match self {
+            Encoding::Raw => {
+                dst.copy_from_slice(src);
+                src.len()
+            }
+            Encoding::Hex => hex::encode(src, dst),
+            Encoding::Base64 => base64::encode(src, dst),
+        }
+    }
+
+    /// Encode the given raw bytes into a `Vec<u8>` of the given encoding
+    #[cfg(feature = "alloc")]
+    pub fn encode_vec<B: AsRef<[u8]>>(self, as_bytes: B) -> Vec<u8> {
+        let bytes = as_bytes.as_ref();
+
+        match self {
+            Encoding::Raw => Vec::from(bytes),
+            Encoding::Hex => {
+                let mut output = vec![0u8; shl!(bytes.len(), 1)];
+                let output_len = self.encode(bytes, &mut output);
+                assert_eq!(output.len(), output_len);
+                output
+            }
+            Encoding::Base64 => {
+                let mut output = vec![0u8; mul!(add!(div!(bytes.len(), 3), 1), 4)];
+                let output_len = self.encode(bytes, &mut output);
+                output.truncate(output_len);
+                output
+            }
+        }
+    }
+
+    /// Decode encoded bytes to the given destination buffer. Returns the size
+    /// of the decoded output, or an error if decoding failed.
+    ///
+    /// Panics if the destination buffer is not sufficiently large given the
+    /// input and encoding format.
+    pub fn decode(self, src: &[u8], dst: &mut [u8]) -> Result<usize, Error> {
+        match self {
+            Encoding::Raw => {
+                dst.copy_from_slice(src);
+                Ok(src.len())
+            }
+            Encoding::Hex => hex::decode(src, dst),
+            Encoding::Base64 => base64::decode(src, dst),
+        }
+    }
+
+    /// Decode the given encoded bytes into a `Vec<u8>`, or return an error if
+    /// they failed to decode correctly
+    #[cfg(feature = "alloc")]
+    pub fn decode_vec<B: AsRef<[u8]>>(self, as_bytes: B) -> Result<Vec<u8>, Error> {
+        let bytes = as_bytes.as_ref();
+
+        match self {
+            Encoding::Raw => Ok(Vec::from(bytes)),
+            Encoding::Hex => {
+                let mut output = vec![0u8; shr!(add!(bytes.len(), 1), 1)];
+                // TODO: whitespace handling?
+                let output_len = self.decode(bytes, &mut output)?;
+                assert_eq!(output.len(), output_len);
+                Ok(output)
+            }
+            Encoding::Base64 => {
+                let mut output = vec![0u8; mul!(add!(div!(bytes.len(), 4), 1), 3)];
+                // TODO: whitespace handling?
+                let output_len = self.decode(bytes, &mut output)?;
+                output.truncate(output_len);
+                Ok(output)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_encode_various_lengths() {
+        let data = [b'X'; 64];
+
+        for i in 0..data.len() {
+            let encoded = Encoding::Base64.encode_vec(&data[..i]);
+
+            // Make sure it round trips
+            let decoded = Encoding::Base64.decode_vec(encoded).unwrap();
+
+            assert_eq!(decoded.as_slice(), &data[..i]);
+        }
+    }
+
+    #[test]
+    fn hex_encode_various_lengths() {
+        let data = [b'X'; 64];
+
+        for i in 0..data.len() {
+            let encoded = Encoding::Hex.encode_vec(&data[..i]);
+
+            // Make sure it round trips
+            let decoded = Encoding::Hex.decode_vec(encoded).unwrap();
+
+            assert_eq!(decoded.as_slice(), &data[..i]);
+        }
+    }
+}

--- a/src/encoding/pkcs8.rs
+++ b/src/encoding/pkcs8.rs
@@ -3,6 +3,7 @@
 //! [RFC 5208]: https://tools.ietf.org/html/rfc5208
 //! [RFC 5915]: https://tools.ietf.org/html/rfc5915
 
+#[cfg(feature = "std")]
 use clear_on_drop::clear::Clear;
 use error::Error;
 #[cfg(feature = "std")]
@@ -28,7 +29,7 @@ pub trait FromPkcs8: Sized {
 
     /// Read `PKCS#8` data from the file at the given path
     #[cfg(feature = "std")]
-    fn read_pkcs8_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+    fn from_pkcs8_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         Self::read_pkcs8(File::open(path)?)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,10 @@
 #![crate_name = "signatory"]
 #![crate_type = "lib"]
 #![no_std]
+#![cfg_attr(
+    all(feature = "nightly", not(feature = "std")),
+    feature(alloc)
+)]
 #![deny(warnings, missing_docs, trivial_casts, trivial_numeric_casts)]
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
@@ -46,7 +50,7 @@
 #[macro_use]
 extern crate std;
 
-#[cfg(feature = "ed25519")]
+#[cfg(any(feature = "encoding", feature = "ed25519"))]
 extern crate clear_on_drop;
 #[cfg(feature = "digest")]
 extern crate digest;
@@ -61,16 +65,15 @@ extern crate sha2;
 pub mod error;
 
 #[cfg(feature = "ecdsa")]
-pub(crate) mod asn1;
-#[cfg(feature = "ecdsa")]
 pub mod curve;
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
 #[cfg(feature = "ed25519")]
 #[macro_use]
 pub mod ed25519;
-#[cfg(feature = "pkcs8")]
-pub mod pkcs8;
+#[cfg(feature = "encoding")]
+pub mod encoding;
+pub(crate) mod prelude;
 mod public_key;
 mod signature;
 mod signer;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,7 @@
+//! Use either of `std` prelude or `alloc` prelude (latter only on nightly)
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub use alloc::prelude::*;
+
+#[cfg(feature = "std")]
+pub use std::prelude::v1::*;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,6 +1,8 @@
 use core::fmt::Debug;
 
 use error::Error;
+#[allow(unused_imports)]
+use prelude::*;
 
 /// Common trait for all signatures
 pub trait Signature: AsRef<[u8]> + Debug + Sized {
@@ -14,9 +16,9 @@ pub trait Signature: AsRef<[u8]> + Debug + Sized {
     }
 
     /// Convert signature into owned byte array
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     #[inline]
-    fn into_vec(self) -> ::std::vec::Vec<u8> {
+    fn into_vec(self) -> Vec<u8> {
         self.as_slice().into()
     }
 }

--- a/src/test_vector.rs
+++ b/src/test_vector.rs
@@ -1,5 +1,7 @@
 //! Test vector structure for signatures
 
+use prelude::*;
+
 /// Signature test vector
 pub struct TestVector {
     /// Algorithm name
@@ -26,8 +28,8 @@ pub struct TestVector {
 
 impl TestVector {
     /// Serialize this test vector as a PKCS#8 document
-    #[cfg(all(feature = "std", feature = "test-vectors"))]
-    pub fn to_pkcs8(&self) -> ::std::vec::Vec<u8> {
+    #[cfg(all(feature = "alloc", feature = "test-vectors"))]
+    pub fn to_pkcs8(&self) -> Vec<u8> {
         // TODO: support other algorithms besides ECDSA P-256
         if self.alg != TestVectorAlgorithm::NISTP256 {
             panic!("not a NIST P-256 test self: {:?}", self.alg);


### PR DESCRIPTION
Factors encoding-related code into a common "encoding" module, and adds the following branchless / data-independent "constant time-ish" encoding implementations:

* `encoding/hex.rs`: Hexadecimal encoding
* `encoding/base64.rs`: Base64 encoding

Both are adapted from these implementations:

https://github.com/Sc00bz/ConstTimeEncoding/

Copyright (c) 2014 Steve "@Sc00bz" Thomas (steve at tobtu dot com)
Licensed under the MIT license (included in comments in each file).