### PR TITLE
Dual license base64.rs and hex.rs as MIT+Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,3 @@ Signatory is distributed under the terms of both the MIT license and the
 Apache License (Version 2.0).
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
-
-Constant-time(ish) Base64 and hex decoding implementations adapted from:
-
-<https://github.com/Sc00bz/ConstTimeEncoding/>
-
-Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com).
-Licensed under the terms of the MIT license. See [LICENSE-MIT](LICENSE-MIT)
-for details.

--- a/src/encoding/base64.rs
+++ b/src/encoding/base64.rs
@@ -6,24 +6,7 @@
 // <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/base64.cpp>
 //
 // Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Derived code is dual licensed MIT + Apache 2 (with permission)
 
 use clear_on_drop::clear::Clear;
 use error::Error;

--- a/src/encoding/hex.rs
+++ b/src/encoding/hex.rs
@@ -6,24 +6,7 @@
 // <https://github.com/Sc00bz/ConstTimeEncoding/blob/master/hex.cpp>
 //
 // Copyright (c) 2014 Steve "Sc00bz" Thomas (steve at tobtu dot com)
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+// Derived code is dual licensed MIT + Apache 2 (with permission)
 
 use error::Error;
 


### PR DESCRIPTION
These are derived from code that was originally licensed as MIT-only, and was therefore explicitly marked as such and called out in the README.md.

The original author @Sc00bz has authorized the derived Rust code to be dual licensed as MIT+Apache 2.0 like the rest of the codebase, so this commit updates the documentation and comments to reflect that.