### PR TITLE
signatory-ring: Debug info for fixed -> ASN.1 sig test

### DIFF
--- a/providers/signatory-ring/src/ecdsa.rs
+++ b/providers/signatory-ring/src/ecdsa.rs
@@ -26,20 +26,16 @@ pub struct P256Signer<S: EcdsaSignature>(EcdsaSigner<NistP256, S>);
 impl FromPkcs8 for P256Signer<Asn1Signature<NistP256>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
     fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error> {
-        Ok(P256Signer(EcdsaSigner::from_pkcs8(
-            &ECDSA_P256_SHA256_ASN1_SIGNING,
-            pkcs8_bytes,
-        )?))
+        let signer = EcdsaSigner::from_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, pkcs8_bytes)?;
+        Ok(P256Signer(signer))
     }
 }
 
 impl FromPkcs8 for P256Signer<FixedSignature<NistP256>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
     fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error> {
-        Ok(P256Signer(EcdsaSigner::from_pkcs8(
-            &ECDSA_P256_SHA256_FIXED_SIGNING,
-            pkcs8_bytes,
-        )?))
+        let signer = EcdsaSigner::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)?;
+        Ok(P256Signer(signer))
     }
 }
 
@@ -268,8 +264,11 @@ mod tests {
 
             let fixed_signature: FixedSignature =
                 signatory::sign_sha256(&signer, vector.msg).unwrap();
-            let asn1_signature = Asn1Signature::from(&fixed_signature);
 
+            // Print this out in case it crashes
+            println!("fixed signature: {:?}", fixed_signature);
+
+            let asn1_signature = Asn1Signature::from(&fixed_signature);
             let verifier = P256Verifier::from(&signer.public_key().unwrap());
             assert!(verifier.verify_sha256(vector.msg, &asn1_signature).is_ok());
         }

--- a/providers/signatory-ring/src/lib.rs
+++ b/providers/signatory-ring/src/lib.rs
@@ -14,6 +14,9 @@ extern crate ring;
 #[cfg_attr(all(test, feature = "ed25519"), macro_use)]
 extern crate signatory;
 extern crate untrusted;
+#[cfg(test)]
+#[macro_use]
+extern crate std;
 
 #[macro_use]
 mod error;


### PR DESCRIPTION
Print the fixed signature generated during the test. `cargo test` will only display it in the event the test fails.

This test failed once sporadically, indicating a (not entirely unexpected) bug in the ASN.1 signature serialization code.

Fuzzing the ASN.1 signature serialization code seems like a good idea.