### PR TITLE
signatory-yubihsm: Normalize secp256k1 signatures to "low S" form

### DIFF
--- a/providers/signatory-yubihsm/Cargo.toml
+++ b/providers/signatory-yubihsm/Cargo.toml
@@ -14,7 +14,9 @@ keywords    = ["cryptography", "ecdsa", "ed25519", "signatures", "yubihsm"]
 circle-ci = { repository = "tendermint/signatory" }
 
 [dependencies]
-yubihsm = "0.15"
+lazy_static = "1"
+secp256k1 = { version = "0.11", optional = true }
+yubihsm = "0.16.0-alpha1"
 
 [dependencies.signatory]
 version = "0.8"
@@ -33,3 +35,4 @@ mockhsm = ["yubihsm/mockhsm"]
 
 [package.metadata.docs.rs]
 rustc-args = ["-Ctarget-feature=+aes"]
+features = ["ecdsa", "ed25519", "mockhsm", "secp256k1"]

--- a/providers/signatory-yubihsm/src/ed25519.rs
+++ b/providers/signatory-yubihsm/src/ed25519.rs
@@ -74,8 +74,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    extern crate signatory_ring;
+    use self::signatory_ring::ed25519::Ed25519Verifier;
+
     use signatory::{self, PublicKeyed};
-    use signatory_ring::ed25519::Ed25519Verifier;
     use std::sync::{Arc, Mutex};
     use yubihsm;
 

--- a/providers/signatory-yubihsm/src/lib.rs
+++ b/providers/signatory-yubihsm/src/lib.rs
@@ -13,11 +13,12 @@
     html_root_url = "https://docs.rs/signatory-yubihsm/0.8.0"
 )]
 
+#[cfg(feature = "secp256k1")]
+#[macro_use]
+extern crate lazy_static;
+#[cfg(feature = "secp256k1")]
+extern crate secp256k1;
 extern crate signatory;
-#[cfg(all(test, feature = "ecdsa"))]
-extern crate signatory_ring;
-#[cfg(all(test, feature = "ecdsa"))]
-extern crate signatory_secp256k1;
 extern crate yubihsm;
 
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
libsecp256k1 rejects ECDSA signatures which are not in "low S" form.

To maximize compatibility with the cryptocurrency ecosystem, this commit runs all YubiHSM2-generated ECDSA-over-secp256k1 signatures through libsecp256k1 first, explicitly normalizing `s` and then using either a strict DER or fixed serialization.