### PR TITLE
Avoid overlapping "PublicKey" names

### DIFF
--- a/providers/signatory-dalek/benches/ed25519.rs
+++ b/providers/signatory-dalek/benches/ed25519.rs
@@ -10,7 +10,7 @@ extern crate signatory_dalek;
 
 use criterion::Criterion;
 use signatory::{
-    ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed, TEST_VECTORS},
+    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, TEST_VECTORS},
     test_vector::TestVector,
     Signature, Verifier,
 };
@@ -28,7 +28,7 @@ fn sign_ed25519(c: &mut Criterion) {
 }
 
 fn verify_ed25519(c: &mut Criterion) {
-    let verifier = Ed25519Verifier::from(&PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
+    let verifier = Ed25519Verifier::from(&Ed25519PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
     let signature = Ed25519Signature::from_bytes(TEST_VECTOR.sig).unwrap();
 
     c.bench_function("dalek: Ed25519 verifier", move |b| {

--- a/providers/signatory-dalek/src/lib.rs
+++ b/providers/signatory-dalek/src/lib.rs
@@ -21,7 +21,7 @@ use ed25519_dalek::{Keypair, SecretKey};
 use sha2::Sha512;
 
 use signatory::{
-    ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed},
+    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed},
     error::{Error, ErrorKind},
     generic_array::typenum::U64,
     DigestSigner, DigestVerifier, PublicKeyed, Signature, Signer, Verifier,
@@ -43,9 +43,9 @@ impl FromSeed for Ed25519Signer {
     }
 }
 
-impl PublicKeyed<PublicKey> for Ed25519Signer {
-    fn public_key(&self) -> Result<PublicKey, Error> {
-        Ok(PublicKey::from_bytes(self.0.public.as_bytes()).unwrap())
+impl PublicKeyed<Ed25519PublicKey> for Ed25519Signer {
+    fn public_key(&self) -> Result<Ed25519PublicKey, Error> {
+        Ok(Ed25519PublicKey::from_bytes(self.0.public.as_bytes()).unwrap())
     }
 }
 
@@ -76,8 +76,8 @@ where
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ed25519Verifier(ed25519_dalek::PublicKey);
 
-impl<'a> From<&'a PublicKey> for Ed25519Verifier {
-    fn from(public_key: &'a PublicKey) -> Self {
+impl<'a> From<&'a Ed25519PublicKey> for Ed25519Verifier {
+    fn from(public_key: &'a Ed25519PublicKey) -> Self {
         Ed25519Verifier(ed25519_dalek::PublicKey::from_bytes(public_key.as_ref()).unwrap())
     }
 }

--- a/providers/signatory-ring/benches/ecdsa.rs
+++ b/providers/signatory-ring/benches/ecdsa.rs
@@ -10,7 +10,7 @@ extern crate signatory_ring;
 use criterion::Criterion;
 use signatory::{
     curve::nistp256::{self, FixedSignature},
-    ecdsa::PublicKey,
+    ecdsa::EcdsaPublicKey,
     encoding::FromPkcs8,
     generic_array::GenericArray,
     test_vector::TestVector,
@@ -31,9 +31,9 @@ fn sign_ecdsa_p256(c: &mut Criterion) {
 
 fn verify_ecdsa_p256(c: &mut Criterion) {
     let signature = FixedSignature::from_bytes(TEST_VECTOR.sig).unwrap();
-    let verifier = P256Verifier::from(&PublicKey::from_untagged_point(GenericArray::from_slice(
-        TEST_VECTOR.pk,
-    )));
+    let verifier = P256Verifier::from(&EcdsaPublicKey::from_untagged_point(
+        GenericArray::from_slice(TEST_VECTOR.pk),
+    ));
 
     c.bench_function("ring: ECDSA (nistp256) verifier", move |b| {
         b.iter(|| verifier.verify_sha256(TEST_VECTOR.msg, &signature).unwrap())

--- a/providers/signatory-ring/benches/ed25519.rs
+++ b/providers/signatory-ring/benches/ed25519.rs
@@ -9,7 +9,7 @@ extern crate signatory_ring;
 
 use criterion::Criterion;
 use signatory::{
-    ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed, TEST_VECTORS},
+    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, TEST_VECTORS},
     test_vector::TestVector,
     Signature, Verifier,
 };
@@ -28,7 +28,7 @@ fn sign_ed25519(c: &mut Criterion) {
 
 fn verify_ed25519(c: &mut Criterion) {
     let signature = Ed25519Signature::from_bytes(TEST_VECTOR.sig).unwrap();
-    let verifier = Ed25519Verifier::from(&PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
+    let verifier = Ed25519Verifier::from(&Ed25519PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
 
     c.bench_function("ring: Ed25519 verifier", move |b| {
         b.iter(|| verifier.verify(TEST_VECTOR.msg, &signature).unwrap())

--- a/providers/signatory-ring/src/ed25519.rs
+++ b/providers/signatory-ring/src/ed25519.rs
@@ -5,7 +5,7 @@ use ring::signature::Ed25519KeyPair;
 use untrusted;
 
 use signatory::{
-    ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed},
+    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed},
     encoding::FromPkcs8,
     error::{Error, ErrorKind::SignatureInvalid},
     PublicKeyed, Signature, Signer, Verifier,
@@ -35,9 +35,9 @@ impl FromPkcs8 for Ed25519Signer {
     }
 }
 
-impl PublicKeyed<PublicKey> for Ed25519Signer {
-    fn public_key(&self) -> Result<PublicKey, Error> {
-        Ok(PublicKey::from_bytes(self.0.public_key_bytes()).unwrap())
+impl PublicKeyed<Ed25519PublicKey> for Ed25519Signer {
+    fn public_key(&self) -> Result<Ed25519PublicKey, Error> {
+        Ok(Ed25519PublicKey::from_bytes(self.0.public_key_bytes()).unwrap())
     }
 }
 
@@ -49,10 +49,10 @@ impl<'a> Signer<&'a [u8], Ed25519Signature> for Ed25519Signer {
 
 /// Ed25519 verifier for *ring*
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Ed25519Verifier(PublicKey);
+pub struct Ed25519Verifier(Ed25519PublicKey);
 
-impl<'a> From<&'a PublicKey> for Ed25519Verifier {
-    fn from(public_key: &'a PublicKey) -> Self {
+impl<'a> From<&'a Ed25519PublicKey> for Ed25519Verifier {
+    fn from(public_key: &'a Ed25519PublicKey) -> Self {
         Ed25519Verifier(*public_key)
     }
 }

--- a/providers/signatory-secp256k1/benches/ecdsa.rs
+++ b/providers/signatory-secp256k1/benches/ecdsa.rs
@@ -11,7 +11,7 @@ extern crate signatory_secp256k1;
 use criterion::Criterion;
 use signatory::{
     curve::secp256k1::{FixedSignature, SHA256_FIXED_SIZE_TEST_VECTORS},
-    ecdsa::PublicKey,
+    ecdsa::EcdsaPublicKey,
     generic_array::GenericArray,
     test_vector::TestVector,
     Sha256Verifier, Signature,
@@ -32,7 +32,8 @@ fn sign_ecdsa(c: &mut Criterion) {
 fn verify_ecdsa(c: &mut Criterion) {
     let signature = FixedSignature::from_bytes(TEST_VECTOR.sig).unwrap();
     let public_key =
-        PublicKey::from_compressed_point(GenericArray::clone_from_slice(TEST_VECTOR.pk)).unwrap();
+        EcdsaPublicKey::from_compressed_point(GenericArray::clone_from_slice(TEST_VECTOR.pk))
+            .unwrap();
     let verifier = EcdsaVerifier::from(&public_key);
 
     c.bench_function("secp256k1: ECDSA verifier", move |b| {

--- a/providers/signatory-sodiumoxide/benches/ed25519.rs
+++ b/providers/signatory-sodiumoxide/benches/ed25519.rs
@@ -10,7 +10,7 @@ extern crate signatory_sodiumoxide;
 
 use criterion::Criterion;
 use signatory::{
-    ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed, TEST_VECTORS},
+    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, TEST_VECTORS},
     test_vector::TestVector,
     Signature, Verifier,
 };
@@ -29,7 +29,7 @@ fn sign_ed25519(c: &mut Criterion) {
 
 fn verify_ed25519(c: &mut Criterion) {
     let signature = Ed25519Signature::from_bytes(TEST_VECTOR.sig).unwrap();
-    let verifier = Ed25519Verifier::from(&PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
+    let verifier = Ed25519Verifier::from(&Ed25519PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
 
     c.bench_function("sodiumoxide: Ed25519 verifier", move |b| {
         b.iter(|| verifier.verify(TEST_VECTOR.msg, &signature).unwrap())

--- a/providers/signatory-sodiumoxide/src/lib.rs
+++ b/providers/signatory-sodiumoxide/src/lib.rs
@@ -15,7 +15,7 @@ extern crate signatory;
 extern crate sodiumoxide;
 
 use signatory::{
-    ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed},
+    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed},
     error::{Error, ErrorKind},
     PublicKeyed, Signature, Signer, Verifier,
 };
@@ -24,7 +24,7 @@ use sodiumoxide::crypto::sign::ed25519::{self as sodiumoxide_ed25519, SecretKey}
 /// Ed25519 signature provider for *sodiumoxide*
 pub struct Ed25519Signer {
     secret_key: SecretKey,
-    public_key: PublicKey,
+    public_key: Ed25519PublicKey,
 }
 
 impl FromSeed for Ed25519Signer {
@@ -35,13 +35,13 @@ impl FromSeed for Ed25519Signer {
 
         Self {
             secret_key,
-            public_key: PublicKey::from_bytes(&public_key.0).unwrap(),
+            public_key: Ed25519PublicKey::from_bytes(&public_key.0).unwrap(),
         }
     }
 }
 
-impl PublicKeyed<PublicKey> for Ed25519Signer {
-    fn public_key(&self) -> Result<PublicKey, Error> {
+impl PublicKeyed<Ed25519PublicKey> for Ed25519Signer {
+    fn public_key(&self) -> Result<Ed25519PublicKey, Error> {
         Ok(self.public_key)
     }
 }
@@ -57,8 +57,8 @@ impl<'a> Signer<&'a [u8], Ed25519Signature> for Ed25519Signer {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ed25519Verifier(sodiumoxide_ed25519::PublicKey);
 
-impl<'a> From<&'a PublicKey> for Ed25519Verifier {
-    fn from(public_key: &'a PublicKey) -> Self {
+impl<'a> From<&'a Ed25519PublicKey> for Ed25519Verifier {
+    fn from(public_key: &'a Ed25519PublicKey) -> Self {
         Ed25519Verifier(sodiumoxide_ed25519::PublicKey::from_slice(public_key.as_bytes()).unwrap())
     }
 }

--- a/providers/signatory-yubihsm/src/ecdsa.rs
+++ b/providers/signatory-yubihsm/src/ecdsa.rs
@@ -11,7 +11,7 @@ use signatory::curve::Secp256k1;
 use signatory::Sha256Signer;
 use signatory::{
     curve::{CurveDigest, NistP256, WeierstrassCurve, WeierstrassCurveKind},
-    ecdsa::{Asn1Signature, FixedSignature, PublicKey},
+    ecdsa::{Asn1Signature, EcdsaPublicKey, FixedSignature},
     error::Error,
     generic_array::GenericArray,
     PublicKeyed, Signature, Signer,
@@ -77,13 +77,13 @@ where
     }
 }
 
-impl<A, C> PublicKeyed<PublicKey<C>> for EcdsaSigner<A, C>
+impl<A, C> PublicKeyed<EcdsaPublicKey<C>> for EcdsaSigner<A, C>
 where
     A: yubihsm::Adapter,
     C: WeierstrassCurve,
 {
     /// Obtain the public key which identifies this signer
-    fn public_key(&self) -> Result<PublicKey<C>, Error> {
+    fn public_key(&self) -> Result<EcdsaPublicKey<C>, Error> {
         let mut session = self.session.lock().unwrap();
 
         let pubkey = yubihsm::get_pubkey(&mut session, self.signing_key_id)
@@ -98,9 +98,9 @@ where
             );
         }
 
-        Ok(PublicKey::from_untagged_point(GenericArray::from_slice(
-            pubkey.as_ref(),
-        )))
+        Ok(EcdsaPublicKey::from_untagged_point(
+            GenericArray::from_slice(pubkey.as_ref()),
+        ))
     }
 }
 

--- a/providers/signatory-yubihsm/src/ed25519.rs
+++ b/providers/signatory-yubihsm/src/ed25519.rs
@@ -4,7 +4,7 @@
 //! call the appropriate signer methods to obtain signers.
 
 use signatory::{
-    ed25519::{Ed25519Signature, PublicKey},
+    ed25519::{Ed25519PublicKey, Ed25519Signature},
     error::{Error, ErrorKind},
     PublicKeyed, Signature, Signer,
 };
@@ -43,11 +43,11 @@ where
     }
 }
 
-impl<A> PublicKeyed<PublicKey> for Ed25519Signer<A>
+impl<A> PublicKeyed<Ed25519PublicKey> for Ed25519Signer<A>
 where
     A: yubihsm::Adapter,
 {
-    fn public_key(&self) -> Result<PublicKey, Error> {
+    fn public_key(&self) -> Result<Ed25519PublicKey, Error> {
         let mut session = self.session.lock().unwrap();
 
         let pubkey = yubihsm::get_pubkey(&mut session, self.signing_key_id)
@@ -57,7 +57,7 @@ where
             return Err(ErrorKind::KeyInvalid.into());
         }
 
-        Ok(PublicKey::from_bytes(pubkey.as_ref()).unwrap())
+        Ok(Ed25519PublicKey::from_bytes(pubkey.as_ref()).unwrap())
     }
 }
 

--- a/src/curve/nistp256/mod.rs
+++ b/src/curve/nistp256/mod.rs
@@ -56,7 +56,7 @@ impl WeierstrassCurve for NistP256 {
 }
 
 /// NIST P-256 public key
-pub type PublicKey = ::ecdsa::PublicKey<NistP256>;
+pub type PublicKey = ::ecdsa::EcdsaPublicKey<NistP256>;
 
 /// ASN.1 DER encoded secp256k1 ECDSA signature
 pub type Asn1Signature = ::ecdsa::Asn1Signature<NistP256>;

--- a/src/curve/secp256k1/mod.rs
+++ b/src/curve/secp256k1/mod.rs
@@ -47,7 +47,7 @@ impl WeierstrassCurve for Secp256k1 {
 }
 
 /// secp256k1 public key
-pub type PublicKey = ::ecdsa::PublicKey<Secp256k1>;
+pub type PublicKey = ::ecdsa::EcdsaPublicKey<Secp256k1>;
 
 /// ASN.1 DER encoded secp256k1 ECDSA signature
 pub type Asn1Signature = ::ecdsa::Asn1Signature<Secp256k1>;

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -4,5 +4,5 @@
 mod public_key;
 mod signature;
 
-pub use self::public_key::PublicKey;
+pub use self::public_key::EcdsaPublicKey;
 pub use self::signature::{asn1::Asn1Signature, fixed::FixedSignature, EcdsaSignature};

--- a/src/ecdsa/public_key.rs
+++ b/src/ecdsa/public_key.rs
@@ -13,12 +13,12 @@ use encoding::{Decode, Encoding};
 use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
+use public_key::PublicKey;
 use util::fmt_colon_delimited_hex;
-use PublicKey as PublicKeyTrait;
 
 /// ECDSA public keys
 #[derive(Clone, Eq, PartialEq)]
-pub enum PublicKey<C: WeierstrassCurve> {
+pub enum EcdsaPublicKey<C: WeierstrassCurve> {
     /// Compressed Weierstrass elliptic curve point
     Compressed(CompressedCurvePoint<C>),
 
@@ -26,7 +26,7 @@ pub enum PublicKey<C: WeierstrassCurve> {
     Uncompressed(UncompressedCurvePoint<C>),
 }
 
-impl<C> PublicKey<C>
+impl<C> EcdsaPublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -44,11 +44,11 @@ where
         if length == C::CompressedPointSize::to_usize() {
             let array = GenericArray::clone_from_slice(slice);
             let point = CompressedCurvePoint::new(array)?;
-            Ok(PublicKey::Compressed(point))
+            Ok(EcdsaPublicKey::Compressed(point))
         } else if length == C::UncompressedPointSize::to_usize() {
             let array = GenericArray::clone_from_slice(slice);
             let point = UncompressedCurvePoint::new(array)?;
-            Ok(PublicKey::Uncompressed(point))
+            Ok(EcdsaPublicKey::Uncompressed(point))
         } else {
             fail!(
                 KeyInvalid,
@@ -70,7 +70,7 @@ where
         B: Into<GenericArray<u8, C::CompressedPointSize>>,
     {
         let point = CompressedCurvePoint::new(into_bytes)?;
-        Ok(PublicKey::Compressed(point))
+        Ok(EcdsaPublicKey::Compressed(point))
     }
 
     /// Create an ECDSA public key from a raw uncompressed point serialized
@@ -84,20 +84,20 @@ where
         tagged_bytes.as_mut_slice()[0] = 0x04;
         tagged_bytes.as_mut_slice()[1..].copy_from_slice(bytes.as_ref());
 
-        PublicKey::Uncompressed(UncompressedCurvePoint::new(tagged_bytes).unwrap())
+        EcdsaPublicKey::Uncompressed(UncompressedCurvePoint::new(tagged_bytes).unwrap())
     }
 
     /// Obtain public key as a byte array reference
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            PublicKey::Compressed(ref point) => point.as_bytes(),
-            PublicKey::Uncompressed(ref point) => point.as_bytes(),
+            EcdsaPublicKey::Compressed(ref point) => point.as_bytes(),
+            EcdsaPublicKey::Uncompressed(ref point) => point.as_bytes(),
         }
     }
 }
 
-impl<C> AsRef<[u8]> for PublicKey<C>
+impl<C> AsRef<[u8]> for EcdsaPublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -107,7 +107,7 @@ where
     }
 }
 
-impl<C> Debug for PublicKey<C>
+impl<C> Debug for EcdsaPublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -119,7 +119,7 @@ where
 }
 
 #[cfg(feature = "encoding")]
-impl<C> Decode for PublicKey<C>
+impl<C> Decode for EcdsaPublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -139,7 +139,7 @@ where
 }
 
 #[cfg(all(feature = "encoding", feature = "alloc"))]
-impl<C> Encode for PublicKey<C>
+impl<C> Encode for EcdsaPublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -155,4 +155,4 @@ where
     }
 }
 
-impl<C: WeierstrassCurve> PublicKeyTrait for PublicKey<C> {}
+impl<C: WeierstrassCurve> PublicKey for EcdsaPublicKey<C> {}

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -16,7 +16,7 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::TEST_VECTORS;
 pub use self::{
-    public_key::{PublicKey, PUBLIC_KEY_SIZE},
+    public_key::{Ed25519PublicKey, PUBLIC_KEY_SIZE},
     seed::{FromSeed, Seed, SEED_SIZE},
     signature::{Ed25519Signature, SIGNATURE_SIZE},
 };

--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -9,20 +9,20 @@ use encoding::{Decode, Encoding};
 use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
+use public_key::PublicKey;
 use util::fmt_colon_delimited_hex;
-use PublicKey as PublicKeyTrait;
 
 /// Size of an Ed25519 public key in bytes (256-bits)
 pub const PUBLIC_KEY_SIZE: usize = 32;
 
 /// Ed25519 public keys
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct PublicKey(pub [u8; PUBLIC_KEY_SIZE]);
+pub struct Ed25519PublicKey(pub [u8; PUBLIC_KEY_SIZE]);
 
-impl PublicKey {
+impl Ed25519PublicKey {
     /// Create an Ed25519 public key from a 32-byte array
     pub fn new(bytes: [u8; PUBLIC_KEY_SIZE]) -> Self {
-        PublicKey(bytes)
+        Ed25519PublicKey(bytes)
     }
 
     /// Create an Ed25519 public key from its serialized (compressed Edwards-y) form
@@ -40,7 +40,7 @@ impl PublicKey {
 
         let mut public_key = [0u8; PUBLIC_KEY_SIZE];
         public_key.copy_from_slice(bytes.as_ref());
-        Ok(PublicKey(public_key))
+        Ok(Ed25519PublicKey(public_key))
     }
 
     /// Obtain public key as a byte array reference
@@ -56,14 +56,14 @@ impl PublicKey {
     }
 }
 
-impl AsRef<[u8]> for PublicKey {
+impl AsRef<[u8]> for Ed25519PublicKey {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-impl Debug for PublicKey {
+impl Debug for Ed25519PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "signatory::ed25519::PublicKey(")?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
@@ -72,7 +72,7 @@ impl Debug for PublicKey {
 }
 
 #[cfg(feature = "encoding")]
-impl Decode for PublicKey {
+impl Decode for Ed25519PublicKey {
     /// Decode an Ed25519 seed from a byte slice with the given encoding (e.g. hex, Base64)
     fn decode(encoded_key: &[u8], encoding: Encoding) -> Result<Self, Error> {
         let mut decoded_key = [0u8; PUBLIC_KEY_SIZE];
@@ -91,11 +91,11 @@ impl Decode for PublicKey {
 }
 
 #[cfg(all(feature = "encoding", feature = "alloc"))]
-impl Encode for PublicKey {
+impl Encode for Ed25519PublicKey {
     /// Encode an Ed25519 seed with the given encoding (e.g. hex, Base64)
     fn encode(&self, encoding: Encoding) -> Vec<u8> {
         encoding.encode_vec(self.as_bytes())
     }
 }
 
-impl PublicKeyTrait for PublicKey {}
+impl PublicKey for Ed25519PublicKey {}

--- a/src/ed25519/test_macros.rs
+++ b/src/ed25519/test_macros.rs
@@ -4,7 +4,9 @@
 macro_rules! ed25519_tests {
     ($signer:ident, $verifier:ident) => {
         use $crate::{
-            ed25519::{Ed25519Signature, FromSeed, PublicKey, Seed, SIGNATURE_SIZE, TEST_VECTORS},
+            ed25519::{
+                Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, SIGNATURE_SIZE, TEST_VECTORS,
+            },
             error::ErrorKind,
             Signature, Signer, Verifier,
         };
@@ -21,7 +23,7 @@ macro_rules! ed25519_tests {
         #[test]
         fn verify_rfc8032_test_vectors() {
             for vector in TEST_VECTORS {
-                let pk = PublicKey::from_bytes(vector.pk).unwrap();
+                let pk = Ed25519PublicKey::from_bytes(vector.pk).unwrap();
                 let verifier = $verifier::from(&pk);
                 let sig = Ed25519Signature::from_bytes(vector.sig).unwrap();
                 assert!(
@@ -34,7 +36,7 @@ macro_rules! ed25519_tests {
         #[test]
         fn rejects_tweaked_rfc8032_test_vectors() {
             for vector in TEST_VECTORS {
-                let pk = PublicKey::from_bytes(vector.pk).unwrap();
+                let pk = Ed25519PublicKey::from_bytes(vector.pk).unwrap();
                 let verifier = $verifier::from(&pk);
 
                 let mut tweaked_sig = [0u8; SIGNATURE_SIZE];

--- a/src/encoding/decode.rs
+++ b/src/encoding/decode.rs
@@ -31,7 +31,7 @@ pub trait Decode: Sized {
     /// Read a file at the given path, decoding the data it contains using
     /// the provided `Encoding`, returning the decoded value or a `Error`.
     #[cfg(feature = "std")]
-    fn decode_file<P: AsRef<Path>>(self, path: P, encoding: Encoding) -> Result<Self, Error> {
+    fn decode_file<P: AsRef<Path>>(path: P, encoding: Encoding) -> Result<Self, Error> {
         Self::decode_reader(&mut File::open(path.as_ref())?, encoding)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,10 @@ mod verifier;
 
 #[cfg(all(feature = "digest", feature = "generic-array"))]
 pub use digest::DigestOutput;
+#[cfg(feature = "ecdsa")]
+pub use ecdsa::{EcdsaPublicKey, EcdsaSignature};
+#[cfg(feature = "ed25519")]
+pub use ed25519::{Ed25519PublicKey, Ed25519Signature};
 pub use error::{Error, ErrorKind};
 pub use public_key::{public_key, PublicKey, PublicKeyed};
 pub use signature::Signature;


### PR DESCRIPTION
To avoid overlap with the `PublicKey` trait (and the need to import
it as `use signatory::PublicKey as PublicKeyTrait`, Renames:

- `ecdsa::PublicKey` => `ecdsa::EcdsaPublicKey`
- `ed25519::PublicKey` => `ed25519::Ed25519PublicKey`

...and also exposes them at the crate toplevel, e.g.:

```
use signatory::EcdsaPublicKey;
use signatory::Ed25519PublicKey;
```