### PR TITLE
encoding: Rename 'decode_*' to 'decode_from_*'

### DIFF
--- a/src/encoding/decode.rs
+++ b/src/encoding/decode.rs
@@ -15,14 +15,14 @@ pub trait Decode: Sized {
 
     /// Decode the given string-alike type with the provided `Encoding`,
     /// returning the decoded value or a `Error`.
-    fn decode_str<S: AsRef<str>>(encoded: S, encoding: Encoding) -> Result<Self, Error> {
+    fn decode_from_str<S: AsRef<str>>(encoded: S, encoding: Encoding) -> Result<Self, Error> {
         Self::decode(encoded.as_ref().as_bytes(), encoding)
     }
 
     /// Decode the data read from the given `io::Read` type with the provided
     /// `Encoding`, returning the decoded value or a `Error`.
     #[cfg(feature = "std")]
-    fn decode_reader<R: Read>(reader: &mut R, encoding: Encoding) -> Result<Self, Error> {
+    fn decode_from_reader<R: Read>(reader: &mut R, encoding: Encoding) -> Result<Self, Error> {
         let mut bytes = ClearOnDrop::new(vec![]);
         reader.read_to_end(bytes.as_mut())?;
         Self::decode(&bytes, encoding)
@@ -31,7 +31,7 @@ pub trait Decode: Sized {
     /// Read a file at the given path, decoding the data it contains using
     /// the provided `Encoding`, returning the decoded value or a `Error`.
     #[cfg(feature = "std")]
-    fn decode_file<P: AsRef<Path>>(path: P, encoding: Encoding) -> Result<Self, Error> {
-        Self::decode_reader(&mut File::open(path.as_ref())?, encoding)
+    fn decode_from_file<P: AsRef<Path>>(path: P, encoding: Encoding) -> Result<Self, Error> {
+        Self::decode_from_reader(&mut File::open(path.as_ref())?, encoding)
     }
 }


### PR DESCRIPTION
This better matches `encode_to_*`