### PR TITLE
.circleci/config.yml: Use Rust 1.29 stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,21 +3,21 @@ version: 2
 jobs:
   build:
     docker:
-    - image: iqlusion/rust-ci:20180905.2 # bump cache keys when modifying this
+    - image: iqlusion/rust-ci:20180913.2 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-20180905.2 # bump save_cache key below too
+        key: cache-20180913.2 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
-          cargo +$RUST_NIGHTLY_VERSION fmt --version
-          cargo +$RUST_NIGHTLY_VERSION fmt --all -- --check
+          cargo fmt --version
+          cargo fmt --all -- --check
     - run:
         name: clippy
         command: |
-          cargo +$RUST_NIGHTLY_VERSION clippy --version
-          cargo +$RUST_NIGHTLY_VERSION clippy --all
+          cargo clippy --version
+          cargo clippy --all
     - run:
         name: build (--no-default-features)
         command: |


### PR DESCRIPTION
rustfmt and clippy are now stable so we no longer need nightly