### PR TITLE
signatory-yubihsm: Fix ECDSA over secp256k1 signing (closes #87)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           rustc --version
           cargo --version
           cargo build --package=signatory-yubihsm
-          cd providers/signatory-yubihsm && cargo test --features=mockhsm
+          cd providers/signatory-yubihsm && cargo test --features=secp256k1,mockhsm
     - run:
         name: audit
         command: |


### PR DESCRIPTION
The `secp256k1` cargo feature was not enabled in CI, and so #83 broke secp256k1 support in the YubiHSM provider.

This fixes secp256k1 support and enables the cargo feature in CI.