### PR TITLE
Generic DigestSigner/DigestVerifier impls

### DIFF
--- a/providers/signatory-dalek/src/lib.rs
+++ b/providers/signatory-dalek/src/lib.rs
@@ -24,7 +24,7 @@ use signatory::{
     ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed},
     error::{Error, ErrorKind},
     generic_array::typenum::U64,
-    DigestSigner, DigestVerifier, PublicKeyed, Signature, Signer, Verifier,
+    PublicKeyed, Signature, Signer, Verifier,
 };
 
 /// Ed25519 signature provider for ed25519-dalek
@@ -83,13 +83,6 @@ where
     }
 }
 
-impl<D> DigestSigner<D, Ed25519Signature> for Ed25519PhSigner
-where
-    D: Digest<OutputSize = U64> + Default,
-{
-    type DigestSize = U64;
-}
-
 /// Ed25519 verifier provider for ed25519-dalek
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ed25519Verifier(ed25519_dalek::PublicKey);
@@ -132,13 +125,6 @@ where
             .verify_prehashed(digest, context, &dalek_sig)
             .map_err(|_| ErrorKind::SignatureInvalid.into())
     }
-}
-
-impl<D> DigestVerifier<D, Ed25519Signature> for Ed25519PhVerifier
-where
-    D: Digest<OutputSize = U64> + Default,
-{
-    type DigestSize = U64;
 }
 
 /// Convert a Signatory seed into a Dalek keypair

--- a/providers/signatory-secp256k1/src/lib.rs
+++ b/providers/signatory-secp256k1/src/lib.rs
@@ -20,7 +20,7 @@ use signatory::{
     curve::secp256k1::{Asn1Signature, FixedSignature, PublicKey},
     digest::Digest,
     generic_array::typenum::U32,
-    DigestSigner, DigestVerifier, Error, PublicKeyed, Signature, Signer, Verifier,
+    Error, PublicKeyed, Signature, Signer, Verifier,
 };
 
 lazy_static! {
@@ -79,14 +79,6 @@ where
     }
 }
 
-// TODO: generic implementation of this for all EcdsaSignatures?
-impl<D> DigestSigner<D, Asn1Signature> for EcdsaSigner
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
-}
-
 impl<D> Signer<D, FixedSignature> for EcdsaSigner
 where
     D: Digest<OutputSize = U32> + Default,
@@ -97,13 +89,6 @@ where
         let sig = SECP256K1_ENGINE.sign(&m, &self.0);
         Ok(FixedSignature::from_bytes(&sig.serialize_compact(&SECP256K1_ENGINE)[..]).unwrap())
     }
-}
-
-impl<D> DigestSigner<D, FixedSignature> for EcdsaSigner
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
 }
 
 /// ECDSA verifier provider for the secp256k1 crate
@@ -136,13 +121,6 @@ where
     }
 }
 
-impl<D> DigestVerifier<D, Asn1Signature> for EcdsaVerifier
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
-}
-
 impl<D> Verifier<D, FixedSignature> for EcdsaVerifier
 where
     D: Digest<OutputSize = U32> + Default,
@@ -158,13 +136,6 @@ where
                 &self.0,
             ).map_err(|e| err!(SignatureInvalid, e))
     }
-}
-
-impl<D> DigestVerifier<D, FixedSignature> for EcdsaVerifier
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
 }
 
 // TODO: test against actual test vectors, rather than just checking if signatures roundtrip

--- a/providers/signatory-yubihsm/src/ecdsa.rs
+++ b/providers/signatory-yubihsm/src/ecdsa.rs
@@ -14,7 +14,7 @@ use signatory::{
     ecdsa::{Asn1Signature, EcdsaPublicKey, FixedSignature},
     error::Error,
     generic_array::{typenum::U32, GenericArray},
-    Digest, DigestSigner, PublicKeyed, Signature, Signer,
+    Digest, PublicKeyed, Signature, Signer,
 };
 use std::{
     marker::PhantomData,
@@ -115,15 +115,6 @@ where
     }
 }
 
-// TODO: generic implementation of this for all EcdsaSignatures?
-#[cfg(feature = "http")]
-impl<D> DigestSigner<D, Asn1Signature<NistP256>> for EcdsaSigner<yubihsm::HttpAdapter, NistP256>
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
-}
-
 #[cfg(feature = "usb")]
 impl<D> Signer<D, Asn1Signature<NistP256>> for EcdsaSigner<yubihsm::UsbAdapter, NistP256>
 where
@@ -133,14 +124,6 @@ where
     fn sign(&self, digest: D) -> Result<Asn1Signature<NistP256>, Error> {
         self.sign_nistp256_asn1(digest)
     }
-}
-
-#[cfg(feature = "usb")]
-impl<D> DigestSigner<D, Asn1Signature<NistP256>> for EcdsaSigner<yubihsm::UsbAdapter, NistP256>
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
 }
 
 #[cfg(feature = "http")]
@@ -154,14 +137,6 @@ where
     }
 }
 
-#[cfg(feature = "http")]
-impl<D> DigestSigner<D, FixedSignature<NistP256>> for EcdsaSigner<yubihsm::HttpAdapter, NistP256>
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
-}
-
 #[cfg(feature = "usb")]
 impl<D> Signer<D, FixedSignature<NistP256>> for EcdsaSigner<yubihsm::UsbAdapter, NistP256>
 where
@@ -171,14 +146,6 @@ where
     fn sign(&self, digest: D) -> Result<FixedSignature<NistP256>, Error> {
         Ok(FixedSignature::from(&self.sign_nistp256_asn1(digest)?))
     }
-}
-
-#[cfg(feature = "usb")]
-impl<D> DigestSigner<D, FixedSignature<NistP256>> for EcdsaSigner<yubihsm::UsbAdapter, NistP256>
-where
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
 }
 
 #[cfg(feature = "secp256k1")]
@@ -198,15 +165,6 @@ where
 }
 
 #[cfg(feature = "secp256k1")]
-impl<A, D> DigestSigner<D, Asn1Signature<Secp256k1>> for EcdsaSigner<A, Secp256k1>
-where
-    A: yubihsm::Adapter,
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
-}
-
-#[cfg(feature = "secp256k1")]
 impl<A, D> Signer<D, FixedSignature<Secp256k1>> for EcdsaSigner<A, Secp256k1>
 where
     A: yubihsm::Adapter,
@@ -222,15 +180,6 @@ where
 
         Ok(FixedSignature::from(fixed_sig))
     }
-}
-
-#[cfg(feature = "secp256k1")]
-impl<A, D> DigestSigner<D, FixedSignature<Secp256k1>> for EcdsaSigner<A, Secp256k1>
-where
-    A: yubihsm::Adapter,
-    D: Digest<OutputSize = U32> + Default,
-{
-    type DigestSize = U32;
 }
 
 impl<A> EcdsaSigner<A, NistP256>

--- a/src/curve/mod.rs
+++ b/src/curve/mod.rs
@@ -1,4 +1,4 @@
-//! Elliptic Curves (presently Weierstrass form only)
+//! Elliptic Curves: Weierstrass form - for use with ECDSA.
 
 use core::{fmt::Debug, hash::Hash, str::FromStr};
 use generic_array::ArrayLength;

--- a/src/ecdsa/digest.rs
+++ b/src/ecdsa/digest.rs
@@ -1,0 +1,45 @@
+//! Impls of `DigestSigner` and `DigestVerifier` for all ECDSA signers and
+//! verifiers which accept digest inputs whose size is equal to the curve's
+//! modulus (i.e. `ScalarSize` for a particular `WeierstrassCurve`).
+
+use super::{Asn1Signature, FixedSignature};
+use curve::WeierstrassCurve;
+use digest::Digest;
+use signer::{DigestSigner, Signer};
+use verifier::{DigestVerifier, Verifier};
+
+impl<C, D, T> DigestSigner<D, Asn1Signature<C>> for T
+where
+    C: WeierstrassCurve,
+    D: Digest<OutputSize = C::ScalarSize>,
+    T: Signer<D, Asn1Signature<C>>,
+{
+    type DigestSize = C::ScalarSize;
+}
+
+impl<C, D, T> DigestSigner<D, FixedSignature<C>> for T
+where
+    C: WeierstrassCurve,
+    D: Digest<OutputSize = C::ScalarSize>,
+    T: Signer<D, FixedSignature<C>>,
+{
+    type DigestSize = C::ScalarSize;
+}
+
+impl<C, D, T> DigestVerifier<D, Asn1Signature<C>> for T
+where
+    C: WeierstrassCurve,
+    D: Digest<OutputSize = C::ScalarSize>,
+    T: Verifier<D, Asn1Signature<C>>,
+{
+    type DigestSize = C::ScalarSize;
+}
+
+impl<C, D, T> DigestVerifier<D, FixedSignature<C>> for T
+where
+    C: WeierstrassCurve,
+    D: Digest<OutputSize = C::ScalarSize>,
+    T: Verifier<D, FixedSignature<C>>,
+{
+    type DigestSize = C::ScalarSize;
+}

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -1,6 +1,8 @@
 //! The Elliptic Curve Digital Signature Algorithm (ECDSA) as specified in
 //! FIPS 186-4 (Digital Signature Standard)
 
+#[cfg(feature = "digest")]
+mod digest;
 mod public_key;
 mod signature;
 

--- a/src/ed25519/digest.rs
+++ b/src/ed25519/digest.rs
@@ -1,0 +1,27 @@
+//! Impls of `DigestSigner` and `DigestVerifier` for all Ed25519 signers and
+//! verifiers which accept 512-bit digest inputs.
+//!
+//! In practice the digest algorithm will always be SHA-512, but we allow for
+//! multiple implementations which conform to the `Digest` API (as opposed to
+//! only doing an impl for `sha2::Sha512`).
+
+use super::Ed25519Signature;
+use digest::{generic_array::typenum::U64, Digest};
+use signer::{DigestSigner, Signer};
+use verifier::{DigestVerifier, Verifier};
+
+impl<D, T> DigestSigner<D, Ed25519Signature> for T
+where
+    D: Digest<OutputSize = U64>,
+    T: Signer<D, Ed25519Signature>,
+{
+    type DigestSize = U64;
+}
+
+impl<D, T> DigestVerifier<D, Ed25519Signature> for T
+where
+    D: Digest<OutputSize = U64>,
+    T: Verifier<D, Ed25519Signature>,
+{
+    type DigestSize = U64;
+}

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -28,6 +28,8 @@
 //! assert!(ed25519::verify(&verifier, msg.as_bytes(), &sig).is_ok());
 //! ```
 
+#[cfg(feature = "digest")]
+mod digest;
 mod public_key;
 mod seed;
 mod signature;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,14 +93,14 @@ pub use ed25519::{
 pub use error::{Error, ErrorKind};
 pub use public_key::{public_key, PublicKey, PublicKeyed};
 pub use signature::Signature;
-#[cfg(all(feature = "digest", feature = "generic-array"))]
+#[cfg(feature = "digest")]
 pub use signer::digest::sign_digest;
 pub use signer::*;
 pub use signer::{
     bytes::sign_bytes,
     sha2::{sign_sha256, sign_sha384, sign_sha512},
 };
-#[cfg(all(feature = "digest", feature = "generic-array"))]
+#[cfg(feature = "digest")]
 pub use verifier::digest::verify_digest;
 pub use verifier::*;
 pub use verifier::{

--- a/src/signer/digest.rs
+++ b/src/signer/digest.rs
@@ -1,7 +1,6 @@
 //! Prehash (a.k.a. "IUF") signing support using the `Digest` trait
 
-use digest::Digest;
-use generic_array::ArrayLength;
+use digest::{generic_array::ArrayLength, Digest};
 
 use error::Error;
 use {Signature, Signer};

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -1,14 +1,14 @@
 //! Unified signing API for all Signatory providers
 
 pub(crate) mod bytes;
-#[cfg(all(feature = "digest", feature = "generic-array"))]
+#[cfg(feature = "digest")]
 pub(crate) mod digest;
 pub(crate) mod sha2;
 
 use error::Error;
 use Signature;
 
-#[cfg(all(feature = "digest", feature = "generic-array"))]
+#[cfg(feature = "digest")]
 pub use self::digest::DigestSigner;
 pub use self::{bytes::ByteSigner, sha2::Sha256Signer};
 

--- a/src/verifier/digest.rs
+++ b/src/verifier/digest.rs
@@ -1,7 +1,6 @@
 //! Prehash (a.k.a. "IUF") verifying support using the `Digest` trait
 
-use digest::Digest;
-use generic_array::ArrayLength;
+use digest::{generic_array::ArrayLength, Digest};
 
 use error::Error;
 use {Signature, Verifier};

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -3,14 +3,14 @@
 use core::fmt::Debug;
 
 pub(crate) mod bytes;
-#[cfg(all(feature = "digest", feature = "generic-array"))]
+#[cfg(feature = "digest")]
 pub(crate) mod digest;
 pub(crate) mod sha2;
 
 use error::Error;
 use Signature;
 
-#[cfg(all(feature = "digest", feature = "generic-array"))]
+#[cfg(feature = "digest")]
 pub use self::digest::DigestVerifier;
 pub use self::{bytes::ByteVerifier, sha2::Sha256Verifier};
 


### PR DESCRIPTION
Eliminates the need for providers to impl `DigestSigner` and `DigestVerifier` by using generic impls for all Ed25519 and ECDSA signers and verifiers.