### PR TITLE
Eliminate ed25519::FromSeed trait

### DIFF
--- a/providers/signatory-dalek/benches/ed25519.rs
+++ b/providers/signatory-dalek/benches/ed25519.rs
@@ -10,7 +10,7 @@ extern crate signatory_dalek;
 
 use criterion::Criterion;
 use signatory::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, TEST_VECTORS},
+    ed25519::{Ed25519PublicKey, Ed25519Signature, Seed, TEST_VECTORS},
     test_vector::TestVector,
     Signature, Verifier,
 };
@@ -20,7 +20,7 @@ use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
 const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from_seed(Seed::from_bytes(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from(&Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("dalek: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())

--- a/providers/signatory-ring/benches/ed25519.rs
+++ b/providers/signatory-ring/benches/ed25519.rs
@@ -9,9 +9,8 @@ extern crate signatory_ring;
 
 use criterion::Criterion;
 use signatory::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, TEST_VECTORS},
-    test_vector::TestVector,
-    Signature, Verifier,
+    ed25519::TEST_VECTORS, test_vector::TestVector, Ed25519PublicKey, Ed25519Seed,
+    Ed25519Signature, Signature, Verifier,
 };
 use signatory_ring::ed25519::{Ed25519Signer, Ed25519Verifier};
 
@@ -19,7 +18,7 @@ use signatory_ring::ed25519::{Ed25519Signer, Ed25519Verifier};
 const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from_seed(Seed::from_bytes(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from(&Ed25519Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("ring: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())

--- a/providers/signatory-ring/src/ed25519.rs
+++ b/providers/signatory-ring/src/ed25519.rs
@@ -5,20 +5,19 @@ use ring::signature::Ed25519KeyPair;
 use untrusted;
 
 use signatory::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed},
     encoding::FromPkcs8,
     error::{Error, ErrorKind},
-    PublicKeyed, Signature, Signer, Verifier,
+    Ed25519PublicKey, Ed25519Seed, Ed25519Signature, PublicKeyed, Signature, Signer, Verifier,
 };
 
 /// Ed25519 signature provider for *ring*
 pub struct Ed25519Signer(Ed25519KeyPair);
 
-impl FromSeed for Ed25519Signer {
+impl<'a> From<&'a Ed25519Seed> for Ed25519Signer {
     /// Create a new Ed25519Signer from an unexpanded seed value
-    fn from_seed<S: Into<Seed>>(seed: S) -> Self {
+    fn from(seed: &'a Ed25519Seed) -> Self {
         let keypair =
-            Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(&seed.into().0[..]))
+            Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(seed.as_secret_slice()))
                 .unwrap();
 
         Ed25519Signer(keypair)

--- a/providers/signatory-sodiumoxide/benches/ed25519.rs
+++ b/providers/signatory-sodiumoxide/benches/ed25519.rs
@@ -10,9 +10,8 @@ extern crate signatory_sodiumoxide;
 
 use criterion::Criterion;
 use signatory::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, TEST_VECTORS},
-    test_vector::TestVector,
-    Signature, Verifier,
+    ed25519::TEST_VECTORS, test_vector::TestVector, Ed25519PublicKey, Ed25519Seed,
+    Ed25519Signature, Signature, Verifier,
 };
 use signatory_sodiumoxide::{Ed25519Signer, Ed25519Verifier};
 
@@ -20,7 +19,7 @@ use signatory_sodiumoxide::{Ed25519Signer, Ed25519Verifier};
 const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from_seed(Seed::from_bytes(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from(&Ed25519Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("sodiumoxide: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())

--- a/providers/signatory-sodiumoxide/src/lib.rs
+++ b/providers/signatory-sodiumoxide/src/lib.rs
@@ -15,9 +15,8 @@ extern crate signatory;
 extern crate sodiumoxide;
 
 use signatory::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature, FromSeed, Seed},
     error::{Error, ErrorKind},
-    PublicKeyed, Signature, Signer, Verifier,
+    Ed25519PublicKey, Ed25519Seed, Ed25519Signature, PublicKeyed, Signature, Signer, Verifier,
 };
 use sodiumoxide::crypto::sign::ed25519::{self as sodiumoxide_ed25519, SecretKey};
 
@@ -27,10 +26,11 @@ pub struct Ed25519Signer {
     public_key: Ed25519PublicKey,
 }
 
-impl FromSeed for Ed25519Signer {
+impl<'a> From<&'a Ed25519Seed> for Ed25519Signer {
     /// Create a new SodiumOxideSigner from an unexpanded seed value
-    fn from_seed<S: Into<Seed>>(seed: S) -> Self {
-        let sodiumoxide_seed = sodiumoxide_ed25519::Seed::from_slice(&seed.into().0[..]).unwrap();
+    fn from(seed: &'a Ed25519Seed) -> Self {
+        let sodiumoxide_seed =
+            sodiumoxide_ed25519::Seed::from_slice(seed.as_secret_slice()).unwrap();
         let (public_key, secret_key) = sodiumoxide_ed25519::keypair_from_seed(&sodiumoxide_seed);
 
         Self {

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -43,7 +43,7 @@ mod test_vectors;
 pub use self::test_vectors::TEST_VECTORS;
 pub use self::{
     public_key::{Ed25519PublicKey, PUBLIC_KEY_SIZE},
-    seed::{FromSeed, Seed, SEED_SIZE},
+    seed::{Seed, SEED_SIZE},
     signature::{Ed25519Signature, SIGNATURE_SIZE},
 };
 use error::Error;

--- a/src/ed25519/seed.rs
+++ b/src/ed25519/seed.rs
@@ -135,13 +135,3 @@ impl From<[u8; 32]> for Seed {
         Seed::new(bytes)
     }
 }
-
-/// Trait for Ed25519 signers that can be initialized from a seed value
-pub trait FromSeed: Sized {
-    /// Create a new Ed25519 signer from a seed (i.e. unexpanded private key)
-    ///
-    /// Seed values are 32-bytes of uniformly random data. This is in contrast
-    /// to an Ed25519 "keypair", which is 64-bytes and includes both the seed
-    /// value and the public key.
-    fn from_seed<S: Into<Seed>>(seed: S) -> Self;
-}

--- a/src/ed25519/test_macros.rs
+++ b/src/ed25519/test_macros.rs
@@ -4,19 +4,16 @@
 macro_rules! ed25519_tests {
     ($signer:ident, $verifier:ident) => {
         use $crate::{
-            ed25519::{
-                self, Ed25519PublicKey, Ed25519Signature, FromSeed, Seed, SIGNATURE_SIZE,
-                TEST_VECTORS,
-            },
+            ed25519::{self, SIGNATURE_SIZE, TEST_VECTORS},
             error::ErrorKind,
-            Signature,
+            Ed25519PublicKey, Ed25519Seed, Ed25519Signature, Signature,
         };
 
         #[test]
         fn sign_rfc8032_test_vectors() {
             for vector in TEST_VECTORS {
-                let seed = Seed::from_bytes(vector.sk).unwrap();
-                let signer = $signer::from_seed(seed);
+                let seed = Ed25519Seed::from_bytes(vector.sk).unwrap();
+                let signer = $signer::from(&seed);
                 assert_eq!(
                     ed25519::sign(&signer, vector.msg).unwrap().as_ref(),
                     vector.sig

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,7 @@ pub use digest::Digest;
 #[cfg(feature = "ecdsa")]
 pub use ecdsa::{EcdsaPublicKey, EcdsaSignature};
 #[cfg(feature = "ed25519")]
-pub use ed25519::{
-    Ed25519PublicKey, Ed25519Signature, FromSeed as FromEd25519Seed, Seed as Ed25519Seed,
-};
+pub use ed25519::{Ed25519PublicKey, Ed25519Signature, Seed as Ed25519Seed};
 pub use error::{Error, ErrorKind};
 pub use public_key::{public_key, PublicKey, PublicKeyed};
 pub use signature::Signature;


### PR DESCRIPTION
The goal of this trait was to make it a bit easier to initialize signers (i.e. accept a seed byte slice or `ed25519::Seed` via `Into`) but really it's just redundant with `From`, so get rid of it.