### PR TITLE
test_vector: Fix PKCS#8 module gating

### DIFF
--- a/src/test_vector/mod.rs
+++ b/src/test_vector/mod.rs
@@ -1,5 +1,6 @@
 //! Test vector structure for signatures
 
+#[cfg(feature = "alloc")]
 mod pkcs8;
 
 /// Signature test vector

--- a/src/test_vector/pkcs8.rs
+++ b/src/test_vector/pkcs8.rs
@@ -22,7 +22,6 @@ const P384_PKCS8_PUBKEY_PREFIX: &[u8] = b"\xa1\x64\x03\x62\x00\x04";
 
 impl TestVector {
     /// Serialize this test vector as a PKCS#8 document
-    #[cfg(all(feature = "alloc", feature = "test-vectors"))]
     pub fn to_pkcs8(&self) -> Vec<u8> {
         // TODO: better serializer than giant hardcoded bytestring literals, like a PKCS#8 library,
         // or at least a less bogus internal PKCS#8 implementation


### PR DESCRIPTION
Gate the whole module, not just the impl of `to_pkcs8()`