### PR TITLE
Derive Clone on Seed; re-export encoding types

### DIFF
--- a/src/ed25519/seed.rs
+++ b/src/ed25519/seed.rs
@@ -19,6 +19,7 @@ pub const SEED_SIZE: usize = 32;
 pub const KEYPAIR_SIZE: usize = 64;
 
 /// Ed25519 seeds: derivation secrets for Ed25519 private scalars/nonce prefixes
+#[derive(Clone)]
 pub struct Seed(pub [u8; SEED_SIZE]);
 
 impl Seed {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@ pub use digest::Digest;
 pub use ecdsa::{EcdsaPublicKey, EcdsaSignature};
 #[cfg(feature = "ed25519")]
 pub use ed25519::{Ed25519PublicKey, Ed25519Signature, Seed as Ed25519Seed};
+#[cfg(feature = "encoding")]
+pub use encoding::*;
 pub use error::{Error, ErrorKind};
 pub use public_key::{public_key, PublicKey, PublicKeyed};
 pub use signature::Signature;


### PR DESCRIPTION
A couple housekeeping items that came up using  Signatory in the KMS.