### PR TITLE
signatory-yubihsm: Expose the yubihsm crate as a pub extern

### DIFF
--- a/providers/signatory-yubihsm/src/lib.rs
+++ b/providers/signatory-yubihsm/src/lib.rs
@@ -19,7 +19,7 @@ extern crate lazy_static;
 #[cfg(feature = "secp256k1")]
 extern crate secp256k1;
 extern crate signatory;
-extern crate yubihsm;
+pub extern crate yubihsm;
 
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
Allows accessing the same version of the crate as the Signatory provider crate is using