### PR TITLE
SEC 1 encoding documentation fixups

### DIFF
--- a/src/curve/mod.rs
+++ b/src/curve/mod.rs
@@ -27,9 +27,10 @@ pub trait WeierstrassCurve:
     type ScalarSize: ArrayLength<u8>;
 
     /// Size of a compressed point for this curve in bytes when serialized
-    /// using `Octet-String-to-Elliptic-Curve-Point` encoding defined in
-    /// section 2.3.4 of SEC 1: Elliptic Curve Cryptography (Version 2.0).
-    /// <http://www.secg.org/sec2-v2.pdf>
+    /// using `Elliptic-Curve-Point-to-Octet-String` encoding defined in
+    /// section 2.3.3 of SEC 1: Elliptic Curve Cryptography (Version 2.0):
+    ///
+    /// <http://www.secg.org/sec1-v2.pdf>
     type CompressedPointSize: ArrayLength<u8>;
 
     /// Size of a raw uncompressed elliptic curve point sans the `0x04`
@@ -37,7 +38,7 @@ pub trait WeierstrassCurve:
     type UntaggedPointSize: ArrayLength<u8>;
 
     /// Size of an uncompressed elliptic curve point serialized using
-    /// the `Octet-String-to-Elliptic-Curve-Point` encoding (including the
+    /// the `Elliptic-Curve-Point-to-Octet-String` encoding (including the
     /// `0x04` tag)
     type UncompressedPointSize: ArrayLength<u8>;
 

--- a/src/curve/nistp256/mod.rs
+++ b/src/curve/nistp256/mod.rs
@@ -35,15 +35,16 @@ impl WeierstrassCurve for NistP256 {
     type ScalarSize = U32;
 
     /// Size of a compressed elliptic curve point serialized using
-    /// `Octet-String-to-Elliptic-Curve-Point` encoding
+    /// `Elliptic-Curve-Point-to-Octet-String` encoding
     type CompressedPointSize = U33;
 
     /// Size of a raw uncompressed elliptic curve point sans the `0x04`
     /// tag byte added in the `UncompressedPointSize` value.
     type UntaggedPointSize = U64;
 
-    /// Size of a raw uncompressed elliptic curve point (i.e sans the `0x04`
-    /// tag added by `Octet-String-to-Elliptic-Curve-Point` encoding)
+    /// Size of an uncompressed elliptic curve point serialized using
+    /// the `Elliptic-Curve-Point-to-Octet-String` encoding (including the
+    /// `0x04` tag)
     type UncompressedPointSize = U65;
 
     /// Maximum size of an ASN.1 DER encoded signature

--- a/src/curve/nistp384/mod.rs
+++ b/src/curve/nistp384/mod.rs
@@ -35,15 +35,16 @@ impl WeierstrassCurve for NistP384 {
     type ScalarSize = U48;
 
     /// Size of a compressed elliptic curve point serialized using
-    /// `Octet-String-to-Elliptic-Curve-Point` encoding
+    /// `Elliptic-Curve-Point-to-Octet-String` encoding
     type CompressedPointSize = U49;
 
     /// Size of a raw uncompressed elliptic curve point sans the `0x04`
     /// tag byte added in the `UncompressedPointSize` value.
     type UntaggedPointSize = U96;
 
-    /// Size of a raw uncompressed elliptic curve point (i.e sans the `0x04`
-    /// tag added by `Octet-String-to-Elliptic-Curve-Point` encoding)
+    /// Size of an uncompressed elliptic curve point serialized using
+    /// the `Elliptic-Curve-Point-to-Octet-String` encoding (including the
+    /// `0x04` tag)
     type UncompressedPointSize = U97;
 
     /// Maximum size of an ASN.1 DER encoded signature

--- a/src/curve/point.rs
+++ b/src/curve/point.rs
@@ -1,6 +1,6 @@
 //! Compressed and uncompressed Weierstrass elliptic curve points serialized
-//! according to the `Octet-String-to-Elliptic-Curve-Point` algorithm described
-//! in SEC 1: Elliptic Curve Cryptography (Version 2.0) section 2.3.4 (page 11)
+//! according to the `Elliptic-Curve-Point-to-Octet-String` algorithm described
+//! in SEC 1: Elliptic Curve Cryptography (Version 2.0) section 2.3.3 (page 10)
 //!
 //! <http://www.secg.org/sec1-v2.pdf>
 
@@ -11,7 +11,7 @@ use super::WeierstrassCurve;
 use error::Error;
 
 /// Compressed elliptic curve points serialized according to the
-/// `Octet-String-to-Elliptic-Curve-Point` algorithm
+/// `Elliptic-Curve-Point-to-Octet-String` algorithm
 pub struct CompressedCurvePoint<C: WeierstrassCurve> {
     /// Raw serialized bytes of the compressed point
     bytes: GenericArray<u8, C::CompressedPointSize>,
@@ -80,7 +80,7 @@ impl<C: WeierstrassCurve> PartialEq for CompressedCurvePoint<C> {
 }
 
 /// Uncompressed elliptic curve points serialized according to the
-/// `Octet-String-to-Elliptic-Curve-Point` algorithm, including the `0x04`
+/// `Elliptic-Curve-Point-to-Octet-String` algorithm, including the `0x04`
 /// tag identifying the bytestring as a curve point.
 pub struct UncompressedCurvePoint<C: WeierstrassCurve> {
     /// Raw serialized bytes of the uncompressed point

--- a/src/curve/secp256k1/mod.rs
+++ b/src/curve/secp256k1/mod.rs
@@ -27,7 +27,7 @@ impl WeierstrassCurve for Secp256k1 {
     type ScalarSize = U32;
 
     /// Size of a compressed elliptic curve point serialized using
-    /// `Octet-String-to-Elliptic-Curve-Point` encoding
+    /// `Elliptic-Curve-Point-to-Octet-String` encoding
     type CompressedPointSize = U33;
 
     /// Size of a raw uncompressed elliptic curve point sans the `0x04`
@@ -35,7 +35,7 @@ impl WeierstrassCurve for Secp256k1 {
     type UntaggedPointSize = U64;
 
     /// Size of a raw uncompressed elliptic curve point (i.e sans the `0x04`
-    /// tag added by `Octet-String-to-Elliptic-Curve-Point` encoding)
+    /// tag added by `Elliptic-Curve-Point-to-Octet-String` encoding)
     type UncompressedPointSize = U65;
 
     /// Maximum size of an ASN.1 DER encoded signature

--- a/src/ecdsa/public_key.rs
+++ b/src/ecdsa/public_key.rs
@@ -32,9 +32,9 @@ where
 {
     /// Create an ECDSA public key from an elliptic curve point
     /// (compressed or uncompressed) encoded using the
-    /// `Octet-String-to-Elliptic-Curve-Point` algorithm described in
+    /// `Elliptic-Curve-Point-to-Octet-String` algorithm described in
     /// SEC 1: Elliptic Curve Cryptography (Version 2.0) section
-    /// 2.3.4 (page 11).
+    /// 2.3.3 (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
     pub fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<Self, Error> {
@@ -60,9 +60,9 @@ where
     }
 
     /// Create an ECDSA public key from an compressed elliptic curve point
-    /// encoded using the `Octet-String-to-Elliptic-Curve-Point` algorithm
+    /// encoded using the `Elliptic-Curve-Point-to-Octet-String` algorithm
     /// described in SEC 1: Elliptic Curve Cryptography (Version 2.0) section
-    /// 2.3.4 (page 11).
+    /// 2.3.3 (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
     pub fn from_compressed_point<B>(into_bytes: B) -> Result<Self, Error>
@@ -77,7 +77,7 @@ where
     /// as a bytestring, without a `0x04`-byte tag.
     ///
     /// This will be twice the modulus size, or 1-byte smaller than the
-    /// `Octet-String-to-Elliptic-Curve-Point` encoding i.e
+    /// `Elliptic-Curve-Point-to-Octet-String` encoding i.e
     /// with the leading `0x04` byte in that encoding removed.
     pub fn from_untagged_point(bytes: &GenericArray<u8, C::UntaggedPointSize>) -> Self {
         let mut tagged_bytes = GenericArray::default();
@@ -126,9 +126,9 @@ where
     /// Decode an ECDSA public key from an elliptic curve point
     /// (compressed or uncompressed) encoded using given `Encoding`
     /// with the underlying bytes serialized using the
-    /// `Octet-String-to-Elliptic-Curve-Point` algorithm described in
+    /// `Elliptic-Curve-Point-to-Octet-String` algorithm described in
     /// SEC 1: Elliptic Curve Cryptography (Version 2.0) section
-    /// 2.3.4 (page 11).
+    /// 2.3.3 (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
     fn decode(encoded_signature: &[u8], encoding: Encoding) -> Result<Self, Error> {
@@ -145,9 +145,9 @@ where
 {
     /// Encode this ECDSA public key (compressed or uncompressed) encoded
     /// using given `Encoding` with the underlying bytes serialized using the
-    /// `Octet-String-to-Elliptic-Curve-Point` algorithm described in
+    /// `Elliptic-Curve-Point-to-Octet-String` algorithm described in
     /// SEC 1: Elliptic Curve Cryptography (Version 2.0) section
-    /// 2.3.4 (page 11).
+    /// 2.3.3 (page 10).
     ///
     /// <http://www.secg.org/sec1-v2.pdf>
     fn encode(&self, encoding: Encoding) -> Vec<u8> {


### PR DESCRIPTION
- Describe the encoding as `Elliptic-Curve-Point-to-Octet-String` from section 2.3.3 of SEC 1 (page 10).
- Fix some copy/paste mistakes where `UncompressedPointSize` was documented as not having the `0x04` tag.