### PR TITLE
ECDSA secret key types and traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ sha2 = { version = "0.7", optional = true }
 
 [features]
 alloc = []
-default = ["pkcs8", "std", "test-vectors"]
+default = ["pkcs8", "rand", "std", "test-vectors"]
 ecdsa = ["generic-array"]
-ed25519 = ["clear_on_drop", "rand"]
+ed25519 = ["clear_on_drop"]
 encoding = ["clear_on_drop"]
 nightly = ["alloc", "clear_on_drop/nightly"]
 pkcs8 = ["encoding"]

--- a/providers/signatory-ring/src/ecdsa/p256.rs
+++ b/providers/signatory-ring/src/ecdsa/p256.rs
@@ -27,37 +27,37 @@ pub type P256Signer<S> = EcdsaSigner<NistP256, S>;
 
 impl FromPkcs8 for P256Signer<Asn1Signature<NistP256>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
-    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error> {
-        Self::new(&ECDSA_P256_SHA256_ASN1_SIGNING, private_key.as_ref())
+    fn from_pkcs8<K: AsRef<[u8]>>(secret_key: K) -> Result<Self, Error> {
+        Self::new(&ECDSA_P256_SHA256_ASN1_SIGNING, secret_key.as_ref())
     }
 }
 
 impl FromPkcs8 for P256Signer<FixedSignature<NistP256>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
-    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error> {
-        Self::new(&ECDSA_P256_SHA256_FIXED_SIGNING, private_key.as_ref())
+    fn from_pkcs8<K: AsRef<[u8]>>(secret_key: K) -> Result<Self, Error> {
+        Self::new(&ECDSA_P256_SHA256_FIXED_SIGNING, secret_key.as_ref())
     }
 }
 
 #[cfg(feature = "std")]
 impl GeneratePkcs8 for P256Signer<Asn1Signature<NistP256>> {
     /// Randomly generate a P-256 **PKCS#8** keypair
-    fn generate_pkcs8() -> Result<pkcs8::PrivateKey, Error> {
+    fn generate_pkcs8() -> Result<pkcs8::SecretKey, Error> {
         let keypair =
             ECDSAKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, &SystemRandom::new())
                 .unwrap();
-        pkcs8::PrivateKey::new(keypair.as_ref())
+        pkcs8::SecretKey::new(keypair.as_ref())
     }
 }
 
 #[cfg(feature = "std")]
 impl GeneratePkcs8 for P256Signer<FixedSignature<NistP256>> {
     /// Randomly generate a P-256 **PKCS#8** keypair
-    fn generate_pkcs8() -> Result<pkcs8::PrivateKey, Error> {
+    fn generate_pkcs8() -> Result<pkcs8::SecretKey, Error> {
         let keypair =
             ECDSAKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
                 .unwrap();
-        pkcs8::PrivateKey::new(keypair.as_ref())
+        pkcs8::SecretKey::new(keypair.as_ref())
     }
 }
 

--- a/providers/signatory-ring/src/ecdsa/p256.rs
+++ b/providers/signatory-ring/src/ecdsa/p256.rs
@@ -7,10 +7,14 @@ use ring::{
         ECDSA_P256_SHA256_FIXED_SIGNING,
     },
 };
+#[cfg(feature = "std")]
+use ring::{rand::SystemRandom, signature::ECDSAKeyPair};
+#[cfg(feature = "std")]
+use signatory::encoding::pkcs8::{self, GeneratePkcs8};
 use signatory::{
     curve::nistp256::NistP256,
     ecdsa::{Asn1Signature, EcdsaPublicKey, EcdsaSignature, FixedSignature},
-    encoding::FromPkcs8,
+    encoding::pkcs8::FromPkcs8,
     error::{Error, ErrorKind::SignatureInvalid},
     PublicKeyed, Sha256Signer, Sha256Verifier,
 };
@@ -23,15 +27,37 @@ pub type P256Signer<S> = EcdsaSigner<NistP256, S>;
 
 impl FromPkcs8 for P256Signer<Asn1Signature<NistP256>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
-    fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error> {
-        Self::new(&ECDSA_P256_SHA256_ASN1_SIGNING, pkcs8_bytes)
+    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error> {
+        Self::new(&ECDSA_P256_SHA256_ASN1_SIGNING, private_key.as_ref())
     }
 }
 
 impl FromPkcs8 for P256Signer<FixedSignature<NistP256>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
-    fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error> {
-        Self::new(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_bytes)
+    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error> {
+        Self::new(&ECDSA_P256_SHA256_FIXED_SIGNING, private_key.as_ref())
+    }
+}
+
+#[cfg(feature = "std")]
+impl GeneratePkcs8 for P256Signer<Asn1Signature<NistP256>> {
+    /// Randomly generate a P-256 **PKCS#8** keypair
+    fn generate_pkcs8() -> Result<pkcs8::PrivateKey, Error> {
+        let keypair =
+            ECDSAKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, &SystemRandom::new())
+                .unwrap();
+        pkcs8::PrivateKey::new(keypair.as_ref())
+    }
+}
+
+#[cfg(feature = "std")]
+impl GeneratePkcs8 for P256Signer<FixedSignature<NistP256>> {
+    /// Randomly generate a P-256 **PKCS#8** keypair
+    fn generate_pkcs8() -> Result<pkcs8::PrivateKey, Error> {
+        let keypair =
+            ECDSAKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .unwrap();
+        pkcs8::PrivateKey::new(keypair.as_ref())
     }
 }
 

--- a/providers/signatory-ring/src/ecdsa/p384.rs
+++ b/providers/signatory-ring/src/ecdsa/p384.rs
@@ -27,37 +27,37 @@ pub type P384Signer<S> = EcdsaSigner<NistP384, S>;
 
 impl FromPkcs8 for P384Signer<Asn1Signature<NistP384>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
-    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error> {
-        Self::new(&ECDSA_P384_SHA384_ASN1_SIGNING, private_key.as_ref())
+    fn from_pkcs8<K: AsRef<[u8]>>(secret_key: K) -> Result<Self, Error> {
+        Self::new(&ECDSA_P384_SHA384_ASN1_SIGNING, secret_key.as_ref())
     }
 }
 
 impl FromPkcs8 for P384Signer<FixedSignature<NistP384>> {
     /// Create a new ECDSA signer which produces fixed-width signatures from a PKCS#8 keypair
-    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error> {
-        Self::new(&ECDSA_P384_SHA384_FIXED_SIGNING, private_key.as_ref())
+    fn from_pkcs8<K: AsRef<[u8]>>(secret_key: K) -> Result<Self, Error> {
+        Self::new(&ECDSA_P384_SHA384_FIXED_SIGNING, secret_key.as_ref())
     }
 }
 
 #[cfg(feature = "std")]
 impl GeneratePkcs8 for P384Signer<Asn1Signature<NistP384>> {
     /// Randomly generate a P-384 **PKCS#8** keypair
-    fn generate_pkcs8() -> Result<pkcs8::PrivateKey, Error> {
+    fn generate_pkcs8() -> Result<pkcs8::SecretKey, Error> {
         let keypair =
             ECDSAKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_ASN1_SIGNING, &SystemRandom::new())
                 .unwrap();
-        pkcs8::PrivateKey::new(keypair.as_ref())
+        pkcs8::SecretKey::new(keypair.as_ref())
     }
 }
 
 #[cfg(feature = "std")]
 impl GeneratePkcs8 for P384Signer<FixedSignature<NistP384>> {
     /// Randomly generate a P-384 **PKCS#8** keypair
-    fn generate_pkcs8() -> Result<pkcs8::PrivateKey, Error> {
+    fn generate_pkcs8() -> Result<pkcs8::SecretKey, Error> {
         let keypair =
             ECDSAKeyPair::generate_pkcs8(&ECDSA_P384_SHA384_FIXED_SIGNING, &SystemRandom::new())
                 .unwrap();
-        pkcs8::PrivateKey::new(keypair.as_ref())
+        pkcs8::SecretKey::new(keypair.as_ref())
     }
 }
 

--- a/providers/signatory-ring/src/ed25519.rs
+++ b/providers/signatory-ring/src/ed25519.rs
@@ -29,8 +29,8 @@ impl<'a> From<&'a Ed25519Seed> for Ed25519Signer {
 
 impl FromPkcs8 for Ed25519Signer {
     /// Create a new Ed25519Signer from a PKCS#8 encoded private key
-    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error> {
-        let keypair = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(private_key.as_ref()))
+    fn from_pkcs8<K: AsRef<[u8]>>(secret_key: K) -> Result<Self, Error> {
+        let keypair = Ed25519KeyPair::from_pkcs8(untrusted::Input::from(secret_key.as_ref()))
             .map_err(|_| Error::from(ErrorKind::KeyInvalid))?;
 
         Ok(Ed25519Signer(keypair))
@@ -40,9 +40,9 @@ impl FromPkcs8 for Ed25519Signer {
 #[cfg(feature = "std")]
 impl GeneratePkcs8 for Ed25519Signer {
     /// Randomly generate an Ed25519 **PKCS#8** keypair
-    fn generate_pkcs8() -> Result<pkcs8::PrivateKey, Error> {
+    fn generate_pkcs8() -> Result<pkcs8::SecretKey, Error> {
         let keypair = Ed25519KeyPair::generate_pkcs8(&SystemRandom::new()).unwrap();
-        pkcs8::PrivateKey::new(keypair.as_ref())
+        pkcs8::SecretKey::new(keypair.as_ref())
     }
 }
 

--- a/providers/signatory-secp256k1/benches/ecdsa.rs
+++ b/providers/signatory-secp256k1/benches/ecdsa.rs
@@ -10,7 +10,7 @@ extern crate signatory_secp256k1;
 
 use criterion::Criterion;
 use signatory::{
-    curve::secp256k1::{FixedSignature, SHA256_FIXED_SIZE_TEST_VECTORS},
+    curve::secp256k1::{FixedSignature, SecretKey, SHA256_FIXED_SIZE_TEST_VECTORS},
     ecdsa::EcdsaPublicKey,
     generic_array::GenericArray,
     test_vector::TestVector,
@@ -22,7 +22,7 @@ use signatory_secp256k1::{EcdsaSigner, EcdsaVerifier};
 const TEST_VECTOR: &TestVector = &SHA256_FIXED_SIZE_TEST_VECTORS[0];
 
 fn sign_ecdsa(c: &mut Criterion) {
-    let signer = EcdsaSigner::from_bytes(TEST_VECTOR.sk).unwrap();
+    let signer = EcdsaSigner::from(&SecretKey::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("secp256k1: ECDSA signer", move |b| {
         b.iter(|| signatory::sign_sha256::<FixedSignature>(&signer, TEST_VECTOR.msg).unwrap())

--- a/src/curve/nistp256/mod.rs
+++ b/src/curve/nistp256/mod.rs
@@ -55,6 +55,9 @@ impl WeierstrassCurve for NistP256 {
     type FixedSignatureSize = U64;
 }
 
+/// NIST P-256 secret key
+pub type SecretKey = ::ecdsa::EcdsaSecretKey<NistP256>;
+
 /// NIST P-256 public key
 pub type PublicKey = ::ecdsa::EcdsaPublicKey<NistP256>;
 

--- a/src/curve/nistp384/mod.rs
+++ b/src/curve/nistp384/mod.rs
@@ -56,6 +56,9 @@ impl WeierstrassCurve for NistP384 {
     type FixedSignatureSize = U96;
 }
 
+/// NIST P-256 secret key
+pub type SecretKey = ::ecdsa::EcdsaSecretKey<NistP384>;
+
 /// NIST P-384 public key
 pub type PublicKey = ::ecdsa::EcdsaPublicKey<NistP384>;
 

--- a/src/curve/nistp384/mod.rs
+++ b/src/curve/nistp384/mod.rs
@@ -18,7 +18,8 @@ pub use self::test_vectors::SHA384_FIXED_SIZE_TEST_VECTORS;
 /// The NIST P-384 elliptic curve: y² = x³ - 3x + b over a ~384-bit prime field
 /// where b is "verifiably random"† constant:
 ///
-/// b = 27580193559959705877849011840389048093056905856361568521428707301988689241309860865136260764883745107765439761230575
+/// b = 2758019355995970587784901184038904809305690585636156852142
+///     8707301988689241309860865136260764883745107765439761230575
 ///
 /// † NOTE: the specific origins of this constant have never been fully disclosed
 ///   (it is the SHA-1 digest of an inexplicable NSA-selected constant)

--- a/src/curve/secp256k1/mod.rs
+++ b/src/curve/secp256k1/mod.rs
@@ -46,6 +46,9 @@ impl WeierstrassCurve for Secp256k1 {
     type FixedSignatureSize = U64;
 }
 
+/// secp256k1 secret key
+pub type SecretKey = ::ecdsa::EcdsaSecretKey<Secp256k1>;
+
 /// secp256k1 public key
 pub type PublicKey = ::ecdsa::EcdsaPublicKey<Secp256k1>;
 

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -2,7 +2,9 @@
 //! FIPS 186-4 (Digital Signature Standard)
 
 mod public_key;
+mod secret_key;
 mod signature;
 
 pub use self::public_key::EcdsaPublicKey;
+pub use self::secret_key::SecretKey as EcdsaSecretKey;
 pub use self::signature::{asn1::Asn1Signature, fixed::FixedSignature, EcdsaSignature};

--- a/src/ecdsa/secret_key.rs
+++ b/src/ecdsa/secret_key.rs
@@ -1,0 +1,135 @@
+//! Raw ECDSA secret keys: `x` value for ECDSA.
+
+use clear_on_drop::clear::Clear;
+use core::marker::PhantomData;
+use generic_array::{typenum::Unsigned, GenericArray};
+#[cfg(feature = "rand")]
+use rand::{CryptoRng, OsRng, RngCore};
+
+use curve::WeierstrassCurve;
+#[cfg(all(feature = "alloc", feature = "encoding"))]
+use encoding::Encode;
+#[cfg(feature = "encoding")]
+use encoding::{Decode, Encoding};
+use error::Error;
+#[cfg(all(feature = "alloc", feature = "encoding"))]
+use prelude::*;
+
+/// Raw ECDSA secret keys: raw scalar value `WeierstrassCurve::ScalarBytes`
+/// in size used as the `x` value for ECDSA.
+pub struct SecretKey<C: WeierstrassCurve> {
+    /// Byte serialization of a secret scalar for ECDSA
+    bytes: GenericArray<u8, C::ScalarSize>,
+
+    /// Placeholder for elliptic curve type
+    curve: PhantomData<C>,
+}
+
+impl<C> SecretKey<C>
+where
+    C: WeierstrassCurve,
+{
+    /// Create a raw ECDSA secret key
+    pub fn new<B>(into_bytes: B) -> Self
+    where
+        B: Into<GenericArray<u8, C::ScalarSize>>,
+    {
+        Self {
+            bytes: into_bytes.into(),
+            curve: PhantomData,
+        }
+    }
+
+    /// Decode a raw ECDSA secret key from the given byte slice
+    pub fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<Self, Error> {
+        let slice = bytes.as_ref();
+        let length = slice.len();
+
+        if length == C::ScalarSize::to_usize() {
+            Ok(Self::new(GenericArray::clone_from_slice(slice)))
+        } else {
+            fail!(
+                KeyInvalid,
+                "invalid length for {:?} secret key: {}",
+                C::CURVE_KIND,
+                length
+            );
+        }
+    }
+
+    /// Generate a new ECDSA secret key using the operating system's
+    /// cryptographically secure random number generator
+    #[cfg(feature = "rand")]
+    pub fn generate() -> Self {
+        let mut csprng = OsRng::new().expect("RNG initialization failure!");
+        Self::generate_from_rng::<OsRng>(&mut csprng)
+    }
+
+    /// Generate a new ECDSA secret key using the provided random number generator
+    #[cfg(feature = "rand")]
+    pub fn generate_from_rng<R: CryptoRng + RngCore>(csprng: &mut R) -> Self {
+        let mut bytes = GenericArray::default();
+        csprng.fill_bytes(bytes.as_mut_slice());
+
+        Self {
+            bytes,
+            curve: PhantomData,
+        }
+    }
+
+    /// Expose this `SecretKey` as a byte slice
+    pub fn as_secret_slice(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+impl<C: WeierstrassCurve> Clone for SecretKey<C> {
+    fn clone(&self) -> Self {
+        Self::new(self.bytes.clone())
+    }
+}
+
+#[cfg(feature = "encoding")]
+impl<C> Decode for SecretKey<C>
+where
+    C: WeierstrassCurve,
+{
+    /// Decode an Ed25519 seed from a byte slice with the given encoding (e.g. hex, Base64)
+    fn decode(encoded_key: &[u8], encoding: Encoding) -> Result<Self, Error> {
+        let mut bytes = GenericArray::default();
+        let decoded_len = encoding.decode(encoded_key, &mut bytes)?;
+
+        ensure!(
+            decoded_len == C::ScalarSize::to_usize(),
+            KeyInvalid,
+            "invalid {}-byte seed (expected {})",
+            decoded_len,
+            C::ScalarSize::to_usize()
+        );
+
+        Ok(Self {
+            bytes,
+            curve: PhantomData,
+        })
+    }
+}
+
+#[cfg(all(feature = "encoding", feature = "alloc"))]
+impl<C> Encode for SecretKey<C>
+where
+    C: WeierstrassCurve,
+{
+    /// Encode an Ed25519 seed with the given encoding (e.g. hex, Base64)
+    fn encode(&self, encoding: Encoding) -> Vec<u8> {
+        encoding.encode_vec(self.as_secret_slice())
+    }
+}
+
+impl<C> Drop for SecretKey<C>
+where
+    C: WeierstrassCurve,
+{
+    fn drop(&mut self) {
+        self.bytes.clear()
+    }
+}

--- a/src/ed25519/seed.rs
+++ b/src/ed25519/seed.rs
@@ -2,6 +2,7 @@
 //! and nonce prefixes
 
 use clear_on_drop::clear::Clear;
+#[cfg(feature = "rand")]
 use rand::{CryptoRng, OsRng, RngCore};
 
 #[cfg(all(feature = "alloc", feature = "encoding"))]
@@ -30,12 +31,14 @@ impl Seed {
 
     /// Generate a new Ed25519 seed using the operating system's
     /// cryptographically secure random number generator
+    #[cfg(feature = "rand")]
     pub fn generate() -> Self {
         let mut csprng = OsRng::new().expect("RNG initialization failure!");
         Self::generate_from_rng::<OsRng>(&mut csprng)
     }
 
     /// Generate a new Ed25519 seed using the provided random number generator
+    #[cfg(feature = "rand")]
     pub fn generate_from_rng<R: CryptoRng + RngCore>(csprng: &mut R) -> Self {
         let mut bytes = [0u8; SEED_SIZE];
         csprng.fill_bytes(&mut bytes[..]);

--- a/src/encoding/encode.rs
+++ b/src/encoding/encode.rs
@@ -4,14 +4,9 @@ use std::{fs::File, io::Write, path::Path};
 #[cfg(unix)]
 use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
 
-use super::Encoding;
+use super::{Encoding, FILE_MODE};
 use error::Error;
 use prelude::*;
-
-/// Mode to use for newly created files when using this trait
-// TODO: make this configurable?
-#[cfg(unix)]
-pub const FILE_MODE: u32 = 0o600;
 
 /// Serialize keys/signatures with the given encoding (e.g. hex, Base64).
 /// Uses constant time encoder/decoder implementations.
@@ -38,7 +33,8 @@ pub trait Encode: Sized {
         encoding: Encoding,
     ) -> Result<usize, Error> {
         let bytes = ClearOnDrop::new(self.encode(encoding));
-        Ok(writer.write(bytes.as_ref())?)
+        writer.write_all(bytes.as_ref())?;
+        Ok(bytes.len())
     }
 
     /// Encode `self` and write it to a file at the given path, returning the

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -13,7 +13,7 @@ mod decode;
 mod encode;
 mod hex;
 #[cfg(feature = "pkcs8")]
-mod pkcs8;
+pub mod pkcs8;
 
 pub use self::decode::Decode;
 #[cfg(feature = "alloc")]
@@ -24,6 +24,11 @@ pub use self::pkcs8::FromPkcs8;
 use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
+
+/// Mode to use for newly created files
+// TODO: make this configurable?
+#[cfg(unix)]
+pub const FILE_MODE: u32 = 0o600;
 
 /// Types of encodings natively supported by Signatory
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/encoding/pkcs8.rs
+++ b/src/encoding/pkcs8.rs
@@ -4,6 +4,8 @@
 //! [RFC 5208]: https://tools.ietf.org/html/rfc5208
 //! [RFC 5915]: https://tools.ietf.org/html/rfc5915
 
+#[cfg(all(unix, feature = "std"))]
+use super::FILE_MODE;
 #[cfg(feature = "std")]
 use clear_on_drop::clear::Clear;
 use error::Error;
@@ -16,13 +18,11 @@ use std::{fs::File, io::Read, path::Path};
 #[cfg(all(unix, feature = "std"))]
 use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
 
-use super::FILE_MODE;
-
 /// Load this type from a **PKCS#8** private key
 pub trait FromPkcs8: Sized {
     /// Load from the given **PKCS#8**-encoded private key, returning `Self`
     /// or an error if the given data couldn't be loaded.
-    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error>;
+    fn from_pkcs8<K: AsRef<[u8]>>(secret_key: K) -> Result<Self, Error>;
 
     /// Read **PKCS#8** data from the given `std::io::Read`.
     #[cfg(feature = "std")]
@@ -48,7 +48,7 @@ pub trait FromPkcs8: Sized {
 pub trait GeneratePkcs8: Sized + FromPkcs8 {
     /// Randomly generate a **PKCS#8** private key for this type loadable
     /// via `from_pkcs8()`.
-    fn generate_pkcs8() -> Result<PrivateKey, Error>;
+    fn generate_pkcs8() -> Result<SecretKey, Error>;
 
     /// Write randomly generated **PKCS#8** private key to the file at the
     /// given path.
@@ -58,7 +58,7 @@ pub trait GeneratePkcs8: Sized + FromPkcs8 {
     /// and replaced.
     #[cfg(unix)]
     fn generate_pkcs8_file<P: AsRef<Path>>(path: P) -> Result<File, Error> {
-        let private_key = Self::generate_pkcs8()?;
+        let secret_key = Self::generate_pkcs8()?;
 
         let mut file = OpenOptions::new()
             .create(true)
@@ -67,7 +67,7 @@ pub trait GeneratePkcs8: Sized + FromPkcs8 {
             .mode(FILE_MODE)
             .open(path)?;
 
-        file.write_all(private_key.as_ref())?;
+        file.write_all(secret_key.as_ref())?;
         Ok(file)
     }
 
@@ -77,35 +77,35 @@ pub trait GeneratePkcs8: Sized + FromPkcs8 {
     /// If the file does not exist, it will be created.
     #[cfg(not(unix))]
     fn generate_pkcs8_file<P: AsRef<Path>>(path: P) -> Result<File, Error> {
-        let private_key = Self::generate_pkcs8()?;
+        let secret_key = Self::generate_pkcs8()?;
         let mut file = File::create(path.as_ref())?;
-        file.write_all(private_key.as_ref())?;
+        file.write_all(secret_key.as_ref())?;
         Ok(file)
     }
 }
 
-/// PKCS#8 private key data
-#[cfg(feature = "std")]
-pub struct PrivateKey(Vec<u8>);
+/// **PKCS#8** keypairs containing public keys and secret keys
+#[cfg(feature = "alloc")]
+pub struct SecretKey(Vec<u8>);
 
-#[cfg(feature = "std")]
-impl PrivateKey {
+#[cfg(feature = "alloc")]
+impl SecretKey {
     /// Create a new **PKCS#8** `PrivateKey` from the given bytes.
     // TODO: parse the document and verify it's well-formed
-    pub fn new(private_key_bytes: &[u8]) -> Result<Self, Error> {
-        Ok(PrivateKey(private_key_bytes.to_vec()))
+    pub fn new(secret_key_bytes: &[u8]) -> Result<Self, Error> {
+        Ok(SecretKey(secret_key_bytes.to_vec()))
     }
 }
 
-#[cfg(feature = "std")]
-impl AsRef<[u8]> for PrivateKey {
+#[cfg(feature = "alloc")]
+impl AsRef<[u8]> for SecretKey {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-#[cfg(feature = "std")]
-impl Drop for PrivateKey {
+#[cfg(feature = "alloc")]
+impl Drop for SecretKey {
     fn drop(&mut self) {
         self.0.clear()
     }

--- a/src/encoding/pkcs8.rs
+++ b/src/encoding/pkcs8.rs
@@ -1,4 +1,5 @@
-//! Support for the `PKCS#8` private key format described in [RFC 5208] and [RFC 5915]
+//! Support for the **PKCS#8** private key format described in [RFC 5208]
+//! and [RFC 5915].
 //!
 //! [RFC 5208]: https://tools.ietf.org/html/rfc5208
 //! [RFC 5915]: https://tools.ietf.org/html/rfc5915
@@ -7,15 +8,23 @@
 use clear_on_drop::clear::Clear;
 use error::Error;
 #[cfg(feature = "std")]
+use prelude::*;
+#[cfg(feature = "std")]
+use std::io::Write;
+#[cfg(feature = "std")]
 use std::{fs::File, io::Read, path::Path};
+#[cfg(all(unix, feature = "std"))]
+use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
 
-/// Instantiate this type from a `PKCS#8` private key
+use super::FILE_MODE;
+
+/// Load this type from a **PKCS#8** private key
 pub trait FromPkcs8: Sized {
-    /// Load the given `PKCS#8`-encoded private key, returning `Self` or an
-    /// error if the given data couldn't be loaded
-    fn from_pkcs8(pkcs8_bytes: &[u8]) -> Result<Self, Error>;
+    /// Load from the given **PKCS#8**-encoded private key, returning `Self`
+    /// or an error if the given data couldn't be loaded.
+    fn from_pkcs8<K: AsRef<[u8]>>(private_key: K) -> Result<Self, Error>;
 
-    /// Read `PKCS#8` data from the given `std::io::Read`
+    /// Read **PKCS#8** data from the given `std::io::Read`.
     #[cfg(feature = "std")]
     fn read_pkcs8<R: Read>(mut reader: R) -> Result<Self, Error> {
         let mut bytes = vec![];
@@ -27,9 +36,77 @@ pub trait FromPkcs8: Sized {
         result
     }
 
-    /// Read `PKCS#8` data from the file at the given path
+    /// Read **PKCS#8** data from the file at the given path.
     #[cfg(feature = "std")]
     fn from_pkcs8_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         Self::read_pkcs8(File::open(path)?)
+    }
+}
+
+/// Generate a random **PKCS#8** private key of this type
+#[cfg(feature = "std")]
+pub trait GeneratePkcs8: Sized + FromPkcs8 {
+    /// Randomly generate a **PKCS#8** private key for this type loadable
+    /// via `from_pkcs8()`.
+    fn generate_pkcs8() -> Result<PrivateKey, Error>;
+
+    /// Write randomly generated **PKCS#8** private key to the file at the
+    /// given path.
+    ///
+    /// If the file does not exist, it will be created with a mode of
+    /// `FILE_MODE` (i.e. `600`). If the file does exist, it will be erased
+    /// and replaced.
+    #[cfg(unix)]
+    fn generate_pkcs8_file<P: AsRef<Path>>(path: P) -> Result<File, Error> {
+        let private_key = Self::generate_pkcs8()?;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(FILE_MODE)
+            .open(path)?;
+
+        file.write_all(private_key.as_ref())?;
+        Ok(file)
+    }
+
+    /// Encode `self` and write it to a file at the given path, returning the
+    /// resulting `File` or a `Error`.
+    ///
+    /// If the file does not exist, it will be created.
+    #[cfg(not(unix))]
+    fn generate_pkcs8_file<P: AsRef<Path>>(path: P) -> Result<File, Error> {
+        let private_key = Self::generate_pkcs8()?;
+        let mut file = File::create(path.as_ref())?;
+        file.write_all(private_key.as_ref())?;
+        Ok(file)
+    }
+}
+
+/// PKCS#8 private key data
+#[cfg(feature = "std")]
+pub struct PrivateKey(Vec<u8>);
+
+#[cfg(feature = "std")]
+impl PrivateKey {
+    /// Create a new **PKCS#8** `PrivateKey` from the given bytes.
+    // TODO: parse the document and verify it's well-formed
+    pub fn new(private_key_bytes: &[u8]) -> Result<Self, Error> {
+        Ok(PrivateKey(private_key_bytes.to_vec()))
+    }
+}
+
+#[cfg(feature = "std")]
+impl AsRef<[u8]> for PrivateKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+#[cfg(feature = "std")]
+impl Drop for PrivateKey {
+    fn drop(&mut self) {
+        self.0.clear()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ mod verifier;
 #[cfg(feature = "digest")]
 pub use digest::Digest;
 #[cfg(feature = "ecdsa")]
-pub use ecdsa::{EcdsaPublicKey, EcdsaSignature};
+pub use ecdsa::{EcdsaPublicKey, EcdsaSecretKey, EcdsaSignature};
 #[cfg(feature = "ed25519")]
 pub use ed25519::{Ed25519PublicKey, Ed25519Signature, Seed as Ed25519Seed};
 #[cfg(feature = "encoding")]


### PR DESCRIPTION
Adds an `EcdsaSecretKey` type for representing raw ECDSA secret keys (private `x` scalars) as commonly used in Bitcoin and other cryptocurrencies.

Also adds a `GeneratePkcs8` trait for randomly generating PKCS#8 keypairs.