### PR TITLE
Remove redundant "namespacing" from type names

### DIFF
--- a/providers/signatory-dalek/benches/ed25519.rs
+++ b/providers/signatory-dalek/benches/ed25519.rs
@@ -9,18 +9,14 @@ extern crate signatory;
 extern crate signatory_dalek;
 
 use criterion::Criterion;
-use signatory::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature, Seed, TEST_VECTORS},
-    test_vector::TestVector,
-    Signature, Verifier,
-};
+use signatory::{ed25519, test_vector::TestVector, Signature, Verifier};
 use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
 
 /// Test vector to use for benchmarking
-const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
+const TEST_VECTOR: &TestVector = &ed25519::TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from(&Seed::from_bytes(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from(&ed25519::Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("dalek: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())
@@ -28,8 +24,8 @@ fn sign_ed25519(c: &mut Criterion) {
 }
 
 fn verify_ed25519(c: &mut Criterion) {
-    let verifier = Ed25519Verifier::from(&Ed25519PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
-    let signature = Ed25519Signature::from_bytes(TEST_VECTOR.sig).unwrap();
+    let verifier = Ed25519Verifier::from(&ed25519::PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
+    let signature = ed25519::Signature::from_bytes(TEST_VECTOR.sig).unwrap();
 
     c.bench_function("dalek: Ed25519 verifier", move |b| {
         b.iter(|| verifier.verify(TEST_VECTOR.msg, &signature).unwrap())

--- a/providers/signatory-ledger-cosval/src/lib.rs
+++ b/providers/signatory-ledger-cosval/src/lib.rs
@@ -16,8 +16,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use signatory::{
-    ed25519::Ed25519PublicKey,
-    ed25519::Ed25519Signature,
+    ed25519::{PublicKey, Signature},
     error::{Error, ErrorKind},
     PublicKeyed, Signer,
 };
@@ -43,25 +42,25 @@ impl Ed25519CosmosAppSigner {
     }
 }
 
-impl PublicKeyed<Ed25519PublicKey> for Ed25519CosmosAppSigner {
+impl PublicKeyed<PublicKey> for Ed25519CosmosAppSigner {
     /// Returns the public key that corresponds cosmos validator app connected to this signer
-    fn public_key(&self) -> Result<Ed25519PublicKey, Error> {
+    fn public_key(&self) -> Result<PublicKey, Error> {
         let app = self.app.lock().unwrap();
 
         match app.public_key() {
-            Ok(pk) => Ok(Ed25519PublicKey(pk)),
+            Ok(pk) => Ok(PublicKey(pk)),
             Err(err) => Err(Error::new(ErrorKind::ProviderError, Some(&err.to_string()))),
         }
     }
 }
 
-impl Signer<Ed25519Signature> for Ed25519CosmosAppSigner {
+impl Signer<Signature> for Ed25519CosmosAppSigner {
     /// c: Compute a compact, fixed-sized signature of the given amino/json vote
-    fn sign(&self, msg: &[u8]) -> Result<Ed25519Signature, Error> {
+    fn sign(&self, msg: &[u8]) -> Result<Signature, Error> {
         let app = self.app.lock().unwrap();
 
         match app.sign(&msg) {
-            Ok(sig) => Ok(Ed25519Signature(sig)),
+            Ok(sig) => Ok(Signature(sig)),
             Err(err) => Err(Error::new(ErrorKind::ProviderError, Some(&err.to_string()))),
         }
     }

--- a/providers/signatory-ring/benches/ecdsa.rs
+++ b/providers/signatory-ring/benches/ecdsa.rs
@@ -10,7 +10,7 @@ extern crate signatory_ring;
 use criterion::Criterion;
 use signatory::{
     curve::nistp256::{self, FixedSignature},
-    ecdsa::EcdsaPublicKey,
+    ecdsa::PublicKey,
     encoding::FromPkcs8,
     generic_array::GenericArray,
     test_vector::TestVector,
@@ -31,9 +31,9 @@ fn sign_ecdsa_p256(c: &mut Criterion) {
 
 fn verify_ecdsa_p256(c: &mut Criterion) {
     let signature = FixedSignature::from_bytes(TEST_VECTOR.sig).unwrap();
-    let verifier = P256Verifier::from(&EcdsaPublicKey::from_untagged_point(
-        GenericArray::from_slice(TEST_VECTOR.pk),
-    ));
+    let verifier = P256Verifier::from(&PublicKey::from_untagged_point(GenericArray::from_slice(
+        TEST_VECTOR.pk,
+    )));
 
     c.bench_function("ring: ECDSA (nistp256) verifier", move |b| {
         b.iter(|| verifier.verify_sha256(TEST_VECTOR.msg, &signature).unwrap())

--- a/providers/signatory-ring/benches/ed25519.rs
+++ b/providers/signatory-ring/benches/ed25519.rs
@@ -8,17 +8,14 @@ extern crate signatory;
 extern crate signatory_ring;
 
 use criterion::Criterion;
-use signatory::{
-    ed25519::TEST_VECTORS, test_vector::TestVector, Ed25519PublicKey, Ed25519Seed,
-    Ed25519Signature, Signature, Verifier,
-};
+use signatory::{ed25519, test_vector::TestVector, Signature, Verifier};
 use signatory_ring::ed25519::{Ed25519Signer, Ed25519Verifier};
 
 /// Test vector to use for benchmarking
-const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
+const TEST_VECTOR: &TestVector = &ed25519::TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from(&Ed25519Seed::from_bytes(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from(&ed25519::Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("ring: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())
@@ -26,8 +23,8 @@ fn sign_ed25519(c: &mut Criterion) {
 }
 
 fn verify_ed25519(c: &mut Criterion) {
-    let signature = Ed25519Signature::from_bytes(TEST_VECTOR.sig).unwrap();
-    let verifier = Ed25519Verifier::from(&Ed25519PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
+    let signature = ed25519::Signature::from_bytes(TEST_VECTOR.sig).unwrap();
+    let verifier = Ed25519Verifier::from(&ed25519::PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
 
     c.bench_function("ring: Ed25519 verifier", move |b| {
         b.iter(|| verifier.verify(TEST_VECTOR.msg, &signature).unwrap())

--- a/providers/signatory-ring/src/ecdsa/p256.rs
+++ b/providers/signatory-ring/src/ecdsa/p256.rs
@@ -13,7 +13,7 @@ use ring::{rand::SystemRandom, signature::ECDSAKeyPair};
 use signatory::encoding::pkcs8::{self, GeneratePkcs8};
 use signatory::{
     curve::nistp256::NistP256,
-    ecdsa::{Asn1Signature, EcdsaPublicKey, EcdsaSignature, FixedSignature},
+    ecdsa::{Asn1Signature, FixedSignature, PublicKey, Signature},
     encoding::pkcs8::FromPkcs8,
     error::{Error, ErrorKind::SignatureInvalid},
     PublicKeyed, Sha256Signer, Sha256Verifier,
@@ -61,11 +61,11 @@ impl GeneratePkcs8 for P256Signer<FixedSignature<NistP256>> {
     }
 }
 
-impl<S> PublicKeyed<EcdsaPublicKey<NistP256>> for P256Signer<S>
+impl<S> PublicKeyed<PublicKey<NistP256>> for P256Signer<S>
 where
-    S: EcdsaSignature + Send + Sync,
+    S: Signature + Send + Sync,
 {
-    fn public_key(&self) -> Result<EcdsaPublicKey<NistP256>, Error> {
+    fn public_key(&self) -> Result<PublicKey<NistP256>, Error> {
         Ok(self.public_key.clone())
     }
 }
@@ -84,10 +84,10 @@ impl Sha256Signer<FixedSignature<NistP256>> for P256Signer<FixedSignature<NistP2
 
 /// NIST P-256 ECDSA verifier
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct P256Verifier(EcdsaPublicKey<NistP256>);
+pub struct P256Verifier(PublicKey<NistP256>);
 
-impl<'a> From<&'a EcdsaPublicKey<NistP256>> for P256Verifier {
-    fn from(public_key: &'a EcdsaPublicKey<NistP256>) -> Self {
+impl<'a> From<&'a PublicKey<NistP256>> for P256Verifier {
+    fn from(public_key: &'a PublicKey<NistP256>) -> Self {
         P256Verifier(public_key.clone())
     }
 }

--- a/providers/signatory-ring/src/ecdsa/p384.rs
+++ b/providers/signatory-ring/src/ecdsa/p384.rs
@@ -13,7 +13,7 @@ use ring::{rand::SystemRandom, signature::ECDSAKeyPair};
 use signatory::encoding::pkcs8::{self, GeneratePkcs8};
 use signatory::{
     curve::nistp384::NistP384,
-    ecdsa::{Asn1Signature, EcdsaPublicKey, EcdsaSignature, FixedSignature},
+    ecdsa::{Asn1Signature, FixedSignature, PublicKey, Signature},
     encoding::FromPkcs8,
     error::{Error, ErrorKind::SignatureInvalid},
     PublicKeyed, Sha384Signer, Sha384Verifier,
@@ -61,12 +61,12 @@ impl GeneratePkcs8 for P384Signer<FixedSignature<NistP384>> {
     }
 }
 
-impl<S> PublicKeyed<EcdsaPublicKey<NistP384>> for P384Signer<S>
+impl<S> PublicKeyed<PublicKey<NistP384>> for P384Signer<S>
 where
-    S: EcdsaSignature + Send + Sync,
+    S: Signature + Send + Sync,
 {
     /// Obtain the public key which identifies this signer
-    fn public_key(&self) -> Result<EcdsaPublicKey<NistP384>, Error> {
+    fn public_key(&self) -> Result<PublicKey<NistP384>, Error> {
         Ok(self.public_key.clone())
     }
 }
@@ -85,10 +85,10 @@ impl Sha384Signer<FixedSignature<NistP384>> for P384Signer<FixedSignature<NistP3
 
 /// NIST P-384 ECDSA verifier
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct P384Verifier(EcdsaPublicKey<NistP384>);
+pub struct P384Verifier(PublicKey<NistP384>);
 
-impl<'a> From<&'a EcdsaPublicKey<NistP384>> for P384Verifier {
-    fn from(public_key: &'a EcdsaPublicKey<NistP384>) -> Self {
+impl<'a> From<&'a PublicKey<NistP384>> for P384Verifier {
+    fn from(public_key: &'a PublicKey<NistP384>) -> Self {
         P384Verifier(public_key.clone())
     }
 }

--- a/providers/signatory-ring/src/ecdsa/signer.rs
+++ b/providers/signatory-ring/src/ecdsa/signer.rs
@@ -8,21 +8,21 @@ use ring::{
 };
 use signatory::{
     curve::WeierstrassCurve,
-    ecdsa::{EcdsaPublicKey, EcdsaSignature},
+    ecdsa::{PublicKey, Signature},
     error::{Error, ErrorKind},
     generic_array::{typenum::Unsigned, GenericArray},
 };
 use untrusted;
 
 /// Generic ECDSA signer which is wrapped with curve and signature-specific types
-pub struct EcdsaSigner<C: WeierstrassCurve, S: EcdsaSignature> {
+pub struct EcdsaSigner<C: WeierstrassCurve, S: Signature> {
     /// *ring* ECDSA keypair
     keypair: KeyPair,
 
     /// ECDSA public key for this signer
     // *ring* does not presently keep a copy of this.
     // See https://github.com/briansmith/ring/issues/672#issuecomment-404669397
-    pub(super) public_key: EcdsaPublicKey<C>,
+    pub(super) public_key: PublicKey<C>,
 
     /// Cryptographically secure random number generator
     csrng: SystemRandom,
@@ -34,7 +34,7 @@ pub struct EcdsaSigner<C: WeierstrassCurve, S: EcdsaSignature> {
 impl<C, S> EcdsaSigner<C, S>
 where
     C: WeierstrassCurve,
-    S: EcdsaSignature,
+    S: Signature,
 {
     /// Create an ECDSA signer and public key from a PKCS#8
     pub(super) fn new(alg: &'static SigningAlgorithm, pkcs8_bytes: &[u8]) -> Result<Self, Error> {
@@ -48,7 +48,7 @@ where
             .checked_sub(<C as WeierstrassCurve>::UntaggedPointSize::to_usize())
             .unwrap();
 
-        let public_key = EcdsaPublicKey::from_untagged_point(&GenericArray::from_slice(
+        let public_key = PublicKey::from_untagged_point(&GenericArray::from_slice(
             &pkcs8_bytes[pubkey_bytes_pos..],
         ));
 

--- a/providers/signatory-ring/src/ed25519.rs
+++ b/providers/signatory-ring/src/ed25519.rs
@@ -7,18 +7,19 @@ use ring::signature::Ed25519KeyPair;
 #[cfg(feature = "std")]
 use signatory::encoding::pkcs8::{self, GeneratePkcs8};
 use signatory::{
+    ed25519,
     encoding::FromPkcs8,
     error::{Error, ErrorKind},
-    Ed25519PublicKey, Ed25519Seed, Ed25519Signature, PublicKeyed, Signature, Signer, Verifier,
+    PublicKeyed, Signature, Signer, Verifier,
 };
 use untrusted;
 
 /// Ed25519 signature provider for *ring*
 pub struct Ed25519Signer(Ed25519KeyPair);
 
-impl<'a> From<&'a Ed25519Seed> for Ed25519Signer {
+impl<'a> From<&'a ed25519::Seed> for Ed25519Signer {
     /// Create a new Ed25519Signer from an unexpanded seed value
-    fn from(seed: &'a Ed25519Seed) -> Self {
+    fn from(seed: &'a ed25519::Seed) -> Self {
         let keypair =
             Ed25519KeyPair::from_seed_unchecked(untrusted::Input::from(seed.as_secret_slice()))
                 .unwrap();
@@ -46,30 +47,30 @@ impl GeneratePkcs8 for Ed25519Signer {
     }
 }
 
-impl PublicKeyed<Ed25519PublicKey> for Ed25519Signer {
-    fn public_key(&self) -> Result<Ed25519PublicKey, Error> {
-        Ok(Ed25519PublicKey::from_bytes(self.0.public_key_bytes()).unwrap())
+impl PublicKeyed<ed25519::PublicKey> for Ed25519Signer {
+    fn public_key(&self) -> Result<ed25519::PublicKey, Error> {
+        Ok(ed25519::PublicKey::from_bytes(self.0.public_key_bytes()).unwrap())
     }
 }
 
-impl Signer<Ed25519Signature> for Ed25519Signer {
-    fn sign(&self, msg: &[u8]) -> Result<Ed25519Signature, Error> {
-        Ok(Ed25519Signature::from_bytes(self.0.sign(msg).as_ref()).unwrap())
+impl Signer<ed25519::Signature> for Ed25519Signer {
+    fn sign(&self, msg: &[u8]) -> Result<ed25519::Signature, Error> {
+        Ok(ed25519::Signature::from_bytes(self.0.sign(msg).as_ref()).unwrap())
     }
 }
 
 /// Ed25519 verifier for *ring*
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Ed25519Verifier(Ed25519PublicKey);
+pub struct Ed25519Verifier(ed25519::PublicKey);
 
-impl<'a> From<&'a Ed25519PublicKey> for Ed25519Verifier {
-    fn from(public_key: &'a Ed25519PublicKey) -> Self {
+impl<'a> From<&'a ed25519::PublicKey> for Ed25519Verifier {
+    fn from(public_key: &'a ed25519::PublicKey) -> Self {
         Ed25519Verifier(*public_key)
     }
 }
 
-impl Verifier<Ed25519Signature> for Ed25519Verifier {
-    fn verify(&self, msg: &[u8], signature: &Ed25519Signature) -> Result<(), Error> {
+impl Verifier<ed25519::Signature> for Ed25519Verifier {
+    fn verify(&self, msg: &[u8], signature: &ed25519::Signature) -> Result<(), Error> {
         ring::signature::verify(
             &ring::signature::ED25519,
             untrusted::Input::from(self.0.as_bytes()),

--- a/providers/signatory-secp256k1/benches/ecdsa.rs
+++ b/providers/signatory-secp256k1/benches/ecdsa.rs
@@ -11,7 +11,7 @@ extern crate signatory_secp256k1;
 use criterion::Criterion;
 use signatory::{
     curve::secp256k1::{FixedSignature, SecretKey, SHA256_FIXED_SIZE_TEST_VECTORS},
-    ecdsa::EcdsaPublicKey,
+    ecdsa::PublicKey,
     generic_array::GenericArray,
     test_vector::TestVector,
     Sha256Verifier, Signature,
@@ -32,8 +32,7 @@ fn sign_ecdsa(c: &mut Criterion) {
 fn verify_ecdsa(c: &mut Criterion) {
     let signature = FixedSignature::from_bytes(TEST_VECTOR.sig).unwrap();
     let public_key =
-        EcdsaPublicKey::from_compressed_point(GenericArray::clone_from_slice(TEST_VECTOR.pk))
-            .unwrap();
+        PublicKey::from_compressed_point(GenericArray::clone_from_slice(TEST_VECTOR.pk)).unwrap();
     let verifier = EcdsaVerifier::from(&public_key);
 
     c.bench_function("secp256k1: ECDSA verifier", move |b| {

--- a/providers/signatory-sodiumoxide/benches/ed25519.rs
+++ b/providers/signatory-sodiumoxide/benches/ed25519.rs
@@ -9,17 +9,14 @@ extern crate signatory;
 extern crate signatory_sodiumoxide;
 
 use criterion::Criterion;
-use signatory::{
-    ed25519::TEST_VECTORS, test_vector::TestVector, Ed25519PublicKey, Ed25519Seed,
-    Ed25519Signature, Signature, Verifier,
-};
+use signatory::{ed25519, test_vector::TestVector, Signature, Verifier};
 use signatory_sodiumoxide::{Ed25519Signer, Ed25519Verifier};
 
 /// Test vector to use for benchmarking
-const TEST_VECTOR: &TestVector = &TEST_VECTORS[4];
+const TEST_VECTOR: &TestVector = &ed25519::TEST_VECTORS[4];
 
 fn sign_ed25519(c: &mut Criterion) {
-    let signer = Ed25519Signer::from(&Ed25519Seed::from_bytes(TEST_VECTOR.sk).unwrap());
+    let signer = Ed25519Signer::from(&ed25519::Seed::from_bytes(TEST_VECTOR.sk).unwrap());
 
     c.bench_function("sodiumoxide: Ed25519 signer", move |b| {
         b.iter(|| signatory::sign(&signer, TEST_VECTOR.msg).unwrap())
@@ -27,8 +24,8 @@ fn sign_ed25519(c: &mut Criterion) {
 }
 
 fn verify_ed25519(c: &mut Criterion) {
-    let signature = Ed25519Signature::from_bytes(TEST_VECTOR.sig).unwrap();
-    let verifier = Ed25519Verifier::from(&Ed25519PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
+    let signature = ed25519::Signature::from_bytes(TEST_VECTOR.sig).unwrap();
+    let verifier = Ed25519Verifier::from(&ed25519::PublicKey::from_bytes(TEST_VECTOR.pk).unwrap());
 
     c.bench_function("sodiumoxide: Ed25519 verifier", move |b| {
         b.iter(|| verifier.verify(TEST_VECTOR.msg, &signature).unwrap())

--- a/providers/signatory-yubihsm/src/ecdsa.rs
+++ b/providers/signatory-yubihsm/src/ecdsa.rs
@@ -9,7 +9,7 @@ use secp256k1;
 use signatory::curve::Secp256k1;
 use signatory::{
     curve::{NistP256, NistP384, WeierstrassCurve, WeierstrassCurveKind},
-    ecdsa::{Asn1Signature, EcdsaPublicKey, FixedSignature},
+    ecdsa::{Asn1Signature, FixedSignature, PublicKey},
     error::Error,
     generic_array::{
         typenum::{U32, U48},
@@ -74,12 +74,12 @@ where
     }
 }
 
-impl<C> PublicKeyed<EcdsaPublicKey<C>> for EcdsaSigner<C>
+impl<C> PublicKeyed<PublicKey<C>> for EcdsaSigner<C>
 where
     C: WeierstrassCurve,
 {
     /// Obtain the public key which identifies this signer
-    fn public_key(&self) -> Result<EcdsaPublicKey<C>, Error> {
+    fn public_key(&self) -> Result<PublicKey<C>, Error> {
         let mut hsm = self.hsm.lock().unwrap();
 
         let pubkey = hsm
@@ -95,9 +95,9 @@ where
             );
         }
 
-        Ok(EcdsaPublicKey::from_untagged_point(
-            GenericArray::from_slice(pubkey.as_ref()),
-        ))
+        Ok(PublicKey::from_untagged_point(GenericArray::from_slice(
+            pubkey.as_ref(),
+        )))
     }
 }
 

--- a/providers/signatory-yubihsm/src/ed25519.rs
+++ b/providers/signatory-yubihsm/src/ed25519.rs
@@ -4,7 +4,7 @@
 //! call the appropriate signer methods to obtain signers.
 
 use signatory::{
-    ed25519::{Ed25519PublicKey, Ed25519Signature},
+    ed25519,
     error::{Error, ErrorKind},
     PublicKeyed, Signature, Signer,
 };
@@ -37,8 +37,8 @@ impl Ed25519Signer {
     }
 }
 
-impl PublicKeyed<Ed25519PublicKey> for Ed25519Signer {
-    fn public_key(&self) -> Result<Ed25519PublicKey, Error> {
+impl PublicKeyed<ed25519::PublicKey> for Ed25519Signer {
+    fn public_key(&self) -> Result<ed25519::PublicKey, Error> {
         let mut hsm = self.hsm.lock().unwrap();
 
         let pubkey = hsm
@@ -49,18 +49,18 @@ impl PublicKeyed<Ed25519PublicKey> for Ed25519Signer {
             return Err(ErrorKind::KeyInvalid.into());
         }
 
-        Ok(Ed25519PublicKey::from_bytes(pubkey.as_ref()).unwrap())
+        Ok(ed25519::PublicKey::from_bytes(pubkey.as_ref()).unwrap())
     }
 }
 
-impl Signer<Ed25519Signature> for Ed25519Signer {
-    fn sign(&self, msg: &[u8]) -> Result<Ed25519Signature, Error> {
+impl Signer<ed25519::Signature> for Ed25519Signer {
+    fn sign(&self, msg: &[u8]) -> Result<ed25519::Signature, Error> {
         let mut hsm = self.hsm.lock().unwrap();
 
         let signature = hsm
             .sign_ed25519(self.signing_key_id.0, msg)
             .map_err(|e| err!(ProviderError, "{}", e))?;
 
-        Ok(Ed25519Signature::from_bytes(signature.as_ref()).unwrap())
+        Ok(ed25519::Signature::from_bytes(signature.as_ref()).unwrap())
     }
 }

--- a/src/ecdsa/curve/nistp256/mod.rs
+++ b/src/ecdsa/curve/nistp256/mod.rs
@@ -56,10 +56,10 @@ impl WeierstrassCurve for NistP256 {
 }
 
 /// NIST P-256 secret key
-pub type SecretKey = ::ecdsa::EcdsaSecretKey<NistP256>;
+pub type SecretKey = ::ecdsa::SecretKey<NistP256>;
 
 /// NIST P-256 public key
-pub type PublicKey = ::ecdsa::EcdsaPublicKey<NistP256>;
+pub type PublicKey = ::ecdsa::PublicKey<NistP256>;
 
 /// ASN.1 DER encoded secp256k1 ECDSA signature
 pub type Asn1Signature = ::ecdsa::Asn1Signature<NistP256>;

--- a/src/ecdsa/curve/nistp384/mod.rs
+++ b/src/ecdsa/curve/nistp384/mod.rs
@@ -57,10 +57,10 @@ impl WeierstrassCurve for NistP384 {
 }
 
 /// NIST P-256 secret key
-pub type SecretKey = ::ecdsa::EcdsaSecretKey<NistP384>;
+pub type SecretKey = ::ecdsa::SecretKey<NistP384>;
 
 /// NIST P-384 public key
-pub type PublicKey = ::ecdsa::EcdsaPublicKey<NistP384>;
+pub type PublicKey = ::ecdsa::PublicKey<NistP384>;
 
 /// ASN.1 DER encoded secp384k1 ECDSA signature
 pub type Asn1Signature = ::ecdsa::Asn1Signature<NistP384>;

--- a/src/ecdsa/curve/secp256k1/mod.rs
+++ b/src/ecdsa/curve/secp256k1/mod.rs
@@ -47,10 +47,10 @@ impl WeierstrassCurve for Secp256k1 {
 }
 
 /// secp256k1 secret key
-pub type SecretKey = ::ecdsa::EcdsaSecretKey<Secp256k1>;
+pub type SecretKey = ::ecdsa::SecretKey<Secp256k1>;
 
 /// secp256k1 public key
-pub type PublicKey = ::ecdsa::EcdsaPublicKey<Secp256k1>;
+pub type PublicKey = ::ecdsa::PublicKey<Secp256k1>;
 
 /// ASN.1 DER encoded secp256k1 ECDSA signature
 pub type Asn1Signature = ::ecdsa::Asn1Signature<Secp256k1>;

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -6,6 +6,6 @@ mod public_key;
 mod secret_key;
 mod signature;
 
-pub use self::public_key::EcdsaPublicKey;
-pub use self::secret_key::SecretKey as EcdsaSecretKey;
-pub use self::signature::{asn1::Asn1Signature, fixed::FixedSignature, EcdsaSignature};
+pub use self::public_key::PublicKey;
+pub use self::secret_key::SecretKey;
+pub use self::signature::{asn1::Asn1Signature, fixed::FixedSignature, Signature};

--- a/src/ecdsa/public_key.rs
+++ b/src/ecdsa/public_key.rs
@@ -15,12 +15,11 @@ use encoding::Encode;
 use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
-use public_key::PublicKey;
 use util::fmt_colon_delimited_hex;
 
 /// ECDSA public keys
 #[derive(Clone, Eq, PartialEq)]
-pub enum EcdsaPublicKey<C: WeierstrassCurve> {
+pub enum PublicKey<C: WeierstrassCurve> {
     /// Compressed Weierstrass elliptic curve point
     Compressed(CompressedCurvePoint<C>),
 
@@ -28,7 +27,7 @@ pub enum EcdsaPublicKey<C: WeierstrassCurve> {
     Uncompressed(UncompressedCurvePoint<C>),
 }
 
-impl<C> EcdsaPublicKey<C>
+impl<C> PublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -46,11 +45,11 @@ where
         if length == C::CompressedPointSize::to_usize() {
             let array = GenericArray::clone_from_slice(slice);
             let point = CompressedCurvePoint::new(array)?;
-            Ok(EcdsaPublicKey::Compressed(point))
+            Ok(PublicKey::Compressed(point))
         } else if length == C::UncompressedPointSize::to_usize() {
             let array = GenericArray::clone_from_slice(slice);
             let point = UncompressedCurvePoint::new(array)?;
-            Ok(EcdsaPublicKey::Uncompressed(point))
+            Ok(PublicKey::Uncompressed(point))
         } else {
             fail!(
                 KeyInvalid,
@@ -72,7 +71,7 @@ where
         B: Into<GenericArray<u8, C::CompressedPointSize>>,
     {
         let point = CompressedCurvePoint::new(into_bytes)?;
-        Ok(EcdsaPublicKey::Compressed(point))
+        Ok(PublicKey::Compressed(point))
     }
 
     /// Create an ECDSA public key from a raw uncompressed point serialized
@@ -86,20 +85,20 @@ where
         tagged_bytes.as_mut_slice()[0] = 0x04;
         tagged_bytes.as_mut_slice()[1..].copy_from_slice(bytes.as_ref());
 
-        EcdsaPublicKey::Uncompressed(UncompressedCurvePoint::new(tagged_bytes).unwrap())
+        PublicKey::Uncompressed(UncompressedCurvePoint::new(tagged_bytes).unwrap())
     }
 
     /// Obtain public key as a byte array reference
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         match self {
-            EcdsaPublicKey::Compressed(ref point) => point.as_bytes(),
-            EcdsaPublicKey::Uncompressed(ref point) => point.as_bytes(),
+            PublicKey::Compressed(ref point) => point.as_bytes(),
+            PublicKey::Uncompressed(ref point) => point.as_bytes(),
         }
     }
 }
 
-impl<C> AsRef<[u8]> for EcdsaPublicKey<C>
+impl<C> AsRef<[u8]> for PublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -109,7 +108,7 @@ where
     }
 }
 
-impl<C> Debug for EcdsaPublicKey<C>
+impl<C> Debug for PublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -121,7 +120,7 @@ where
 }
 
 #[cfg(feature = "encoding")]
-impl<C> Decode for EcdsaPublicKey<C>
+impl<C> Decode for PublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -141,7 +140,7 @@ where
 }
 
 #[cfg(all(feature = "encoding", feature = "alloc"))]
-impl<C> Encode for EcdsaPublicKey<C>
+impl<C> Encode for PublicKey<C>
 where
     C: WeierstrassCurve,
 {
@@ -157,4 +156,4 @@ where
     }
 }
 
-impl<C: WeierstrassCurve> PublicKey for EcdsaPublicKey<C> {}
+impl<C: WeierstrassCurve> ::PublicKey for PublicKey<C> {}

--- a/src/ecdsa/signature/asn1.rs
+++ b/src/ecdsa/signature/asn1.rs
@@ -7,8 +7,9 @@ use generic_array::GenericArray;
 #[cfg(feature = "encoding")]
 use subtle_encoding::Encoding;
 
-use super::{fixed::FixedSignature, scalars::ScalarPair, EcdsaSignature};
+use super::{fixed::FixedSignature, scalars::ScalarPair};
 use curve::WeierstrassCurve;
+use ecdsa;
 #[cfg(feature = "encoding")]
 use encoding::Decode;
 #[cfg(all(feature = "alloc", feature = "encoding"))]
@@ -17,7 +18,6 @@ use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
 use util::fmt_colon_delimited_hex;
-use Signature;
 
 /// ECDSA signatures encoded as ASN.1 DER
 #[derive(Clone, PartialEq, Eq)]
@@ -32,7 +32,7 @@ pub struct Asn1Signature<C: WeierstrassCurve> {
     pub(super) curve: PhantomData<C>,
 }
 
-impl<C> Signature for Asn1Signature<C>
+impl<C> ::Signature for Asn1Signature<C>
 where
     C: WeierstrassCurve,
 {
@@ -68,7 +68,7 @@ where
     }
 }
 
-impl<C: WeierstrassCurve> EcdsaSignature for Asn1Signature<C> {}
+impl<C: WeierstrassCurve> ecdsa::Signature for Asn1Signature<C> {}
 
 impl<C> AsRef<[u8]> for Asn1Signature<C>
 where

--- a/src/ecdsa/signature/fixed.rs
+++ b/src/ecdsa/signature/fixed.rs
@@ -6,8 +6,8 @@ use generic_array::{typenum::Unsigned, GenericArray};
 #[cfg(feature = "encoding")]
 use subtle_encoding::Encoding;
 
-use super::EcdsaSignature;
 use curve::WeierstrassCurve;
+use ecdsa;
 #[cfg(feature = "encoding")]
 use encoding::Decode;
 #[cfg(all(feature = "alloc", feature = "encoding"))]
@@ -16,7 +16,6 @@ use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
 use util::fmt_colon_delimited_hex;
-use Signature;
 
 /// ECDSA signatures serialized in a compact, fixed-sized form
 #[derive(Clone, PartialEq, Eq)]
@@ -28,7 +27,7 @@ pub struct FixedSignature<C: WeierstrassCurve> {
     curve: PhantomData<C>,
 }
 
-impl<C> Signature for FixedSignature<C>
+impl<C> ::Signature for FixedSignature<C>
 where
     C: WeierstrassCurve,
 {
@@ -46,7 +45,7 @@ where
     }
 }
 
-impl<C: WeierstrassCurve> EcdsaSignature for FixedSignature<C> {}
+impl<C: WeierstrassCurve> ecdsa::Signature for FixedSignature<C> {}
 
 impl<C> FixedSignature<C>
 where

--- a/src/ecdsa/signature/mod.rs
+++ b/src/ecdsa/signature/mod.rs
@@ -9,7 +9,5 @@ pub(crate) mod fixed;
 /// Signature `r` and `s` values parsed as `ScalarPair`
 pub(crate) mod scalars;
 
-use Signature;
-
 /// Marker trait for ECDSA signatures
-pub trait EcdsaSignature: Signature {}
+pub trait Signature: ::Signature {}

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -42,9 +42,9 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::TEST_VECTORS;
 pub use self::{
-    public_key::{Ed25519PublicKey, PUBLIC_KEY_SIZE},
+    public_key::{PublicKey, PUBLIC_KEY_SIZE},
     seed::{Seed, SEED_SIZE},
-    signature::{Ed25519Signature, SIGNATURE_SIZE},
+    signature::{Signature, SIGNATURE_SIZE},
 };
 use error::Error;
 use public_key::PublicKeyed;
@@ -52,22 +52,18 @@ use signer::Signer;
 use verifier::Verifier;
 
 /// Get the public key for the given public keyed object (i.e. a `Signer`)
-pub fn public_key(keyed: &PublicKeyed<Ed25519PublicKey>) -> Result<Ed25519PublicKey, Error> {
+pub fn public_key(keyed: &PublicKeyed<PublicKey>) -> Result<PublicKey, Error> {
     keyed.public_key()
 }
 
 /// Sign the given message slice with the given Ed25519 signer
 #[inline]
-pub fn sign(signer: &Signer<Ed25519Signature>, msg: &[u8]) -> Result<Ed25519Signature, Error> {
+pub fn sign(signer: &Signer<Signature>, msg: &[u8]) -> Result<Signature, Error> {
     super::sign(signer, msg)
 }
 
 /// Verify the given message slice with the given Ed25519 verifier
 #[inline]
-pub fn verify(
-    verifier: &Verifier<Ed25519Signature>,
-    msg: &[u8],
-    sig: &Ed25519Signature,
-) -> Result<(), Error> {
+pub fn verify(verifier: &Verifier<Signature>, msg: &[u8], sig: &Signature) -> Result<(), Error> {
     super::verify(verifier, msg, sig)
 }

--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -11,7 +11,6 @@ use encoding::Encode;
 use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
-use public_key::PublicKey;
 use util::fmt_colon_delimited_hex;
 
 /// Size of an Ed25519 public key in bytes (256-bits)
@@ -19,12 +18,12 @@ pub const PUBLIC_KEY_SIZE: usize = 32;
 
 /// Ed25519 public keys
 #[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct Ed25519PublicKey(pub [u8; PUBLIC_KEY_SIZE]);
+pub struct PublicKey(pub [u8; PUBLIC_KEY_SIZE]);
 
-impl Ed25519PublicKey {
+impl PublicKey {
     /// Create an Ed25519 public key from a 32-byte array
     pub fn new(bytes: [u8; PUBLIC_KEY_SIZE]) -> Self {
-        Ed25519PublicKey(bytes)
+        PublicKey(bytes)
     }
 
     /// Create an Ed25519 public key from its serialized (compressed Edwards-y) form
@@ -42,7 +41,7 @@ impl Ed25519PublicKey {
 
         let mut public_key = [0u8; PUBLIC_KEY_SIZE];
         public_key.copy_from_slice(bytes.as_ref());
-        Ok(Ed25519PublicKey(public_key))
+        Ok(PublicKey(public_key))
     }
 
     /// Obtain public key as a byte array reference
@@ -58,14 +57,14 @@ impl Ed25519PublicKey {
     }
 }
 
-impl AsRef<[u8]> for Ed25519PublicKey {
+impl AsRef<[u8]> for PublicKey {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-impl Debug for Ed25519PublicKey {
+impl Debug for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "signatory::ed25519::PublicKey(")?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
@@ -74,7 +73,7 @@ impl Debug for Ed25519PublicKey {
 }
 
 #[cfg(feature = "encoding")]
-impl Decode for Ed25519PublicKey {
+impl Decode for PublicKey {
     /// Decode an Ed25519 seed from a byte slice with the given encoding (e.g. hex, Base64)
     fn decode<E: Encoding>(encoded_key: &[u8], encoding: &E) -> Result<Self, Error> {
         let mut decoded_key = [0u8; PUBLIC_KEY_SIZE];
@@ -93,11 +92,11 @@ impl Decode for Ed25519PublicKey {
 }
 
 #[cfg(all(feature = "encoding", feature = "alloc"))]
-impl Encode for Ed25519PublicKey {
+impl Encode for PublicKey {
     /// Encode an Ed25519 seed with the given encoding (e.g. hex, Base64)
     fn encode<E: Encoding>(&self, encoding: &E) -> Vec<u8> {
         encoding.encode(self.as_bytes())
     }
 }
 
-impl PublicKey for Ed25519PublicKey {}
+impl ::PublicKey for PublicKey {}

--- a/src/ed25519/signature.rs
+++ b/src/ed25519/signature.rs
@@ -11,20 +11,20 @@ use encoding::Encode;
 use error::Error;
 #[allow(unused_imports)]
 use prelude::*;
+use signature::Signature as SignatureTrait;
 use util::fmt_colon_delimited_hex;
-use Signature;
 
 /// Size of an Ed25519 signature in bytes (512-bits)
 pub const SIGNATURE_SIZE: usize = 64;
 
 /// Ed25519 signatures
 #[derive(Clone)]
-pub struct Ed25519Signature(pub [u8; SIGNATURE_SIZE]);
+pub struct Signature(pub [u8; SIGNATURE_SIZE]);
 
-impl Ed25519Signature {
+impl Signature {
     /// Create an Ed25519 signature from a 32-byte array
     pub fn new(bytes: [u8; SIGNATURE_SIZE]) -> Self {
-        Ed25519Signature(bytes)
+        Signature(bytes)
     }
 
     /// Obtain signature as a byte array reference
@@ -40,13 +40,13 @@ impl Ed25519Signature {
     }
 }
 
-impl AsRef<[u8]> for Ed25519Signature {
+impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
     }
 }
 
-impl Debug for Ed25519Signature {
+impl Debug for Signature {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "signatory::ed25519::Signature(")?;
         fmt_colon_delimited_hex(f, self.as_ref())?;
@@ -55,7 +55,7 @@ impl Debug for Ed25519Signature {
 }
 
 #[cfg(feature = "encoding")]
-impl Decode for Ed25519Signature {
+impl Decode for Signature {
     /// Decode an Ed25519 signature from a byte slice with the given encoding
     /// (e.g. hex, Base64)
     fn decode<E: Encoding>(encoded_signature: &[u8], encoding: &E) -> Result<Self, Error> {
@@ -75,22 +75,22 @@ impl Decode for Ed25519Signature {
 }
 
 #[cfg(all(feature = "encoding", feature = "alloc"))]
-impl Encode for Ed25519Signature {
+impl Encode for Signature {
     /// Encode an Ed25519 signature with the given encoding (e.g. hex, Base64)
     fn encode<E: Encoding>(&self, encoding: &E) -> Vec<u8> {
         encoding.encode(self.as_ref())
     }
 }
 
-impl Eq for Ed25519Signature {}
+impl Eq for Signature {}
 
-impl PartialEq for Ed25519Signature {
+impl PartialEq for Signature {
     fn eq(&self, other: &Self) -> bool {
         self.0[..] == other.0[..]
     }
 }
 
-impl Signature for Ed25519Signature {
+impl SignatureTrait for Signature {
     /// Create an Ed25519 signature from its serialized byte representation
     fn from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<Self, Error> {
         ensure!(
@@ -103,6 +103,6 @@ impl Signature for Ed25519Signature {
 
         let mut signature = [0u8; SIGNATURE_SIZE];
         signature.copy_from_slice(bytes.as_ref());
-        Ok(Ed25519Signature(signature))
+        Ok(Signature(signature))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,9 +85,13 @@ mod verifier;
 #[cfg(feature = "digest")]
 pub use digest::Digest;
 #[cfg(feature = "ecdsa")]
-pub use ecdsa::{curve, EcdsaPublicKey, EcdsaSecretKey, EcdsaSignature};
+pub use ecdsa::{
+    curve, PublicKey as EcdsaPublicKey, SecretKey as EcdsaSecretKey, Signature as EcdsaSignature,
+};
 #[cfg(feature = "ed25519")]
-pub use ed25519::{Ed25519PublicKey, Ed25519Signature, Seed as Ed25519Seed};
+pub use ed25519::{
+    PublicKey as Ed25519PublicKey, Seed as Ed25519Seed, Signature as Ed25519Signature,
+};
 #[cfg(feature = "encoding")]
 pub use encoding::*;
 pub use error::{Error, ErrorKind};


### PR DESCRIPTION
* `Ed25519PublicKey` => `ed25519::PublicKey`
* `Ed25519Signature` => `ed25519::Signature`
* `EcdsaPublicKey` => `ecdsa::PublicKey`
* `EcdsaSignature` => `ecdsa::Signature`

These names were prefixed with the signature type previously to avoid clashes with traits of the same name (i.e. `signatory::PublicKey` and `signatory::Signature`) however the namespace clash can also be avoided by using the `ed25519` and `ecdsa` module names.

This is considered a Rust best practice:

https://github.com/rust-lang/rfcs/pull/356