### PR TITLE
Rustdoc (i.e. API) + licensing doc improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
         command: |
           rustc --version
           cargo --version
-          cargo test --features=ecdsa,ed25519
+          cargo test --lib --features=ecdsa,ed25519
     - run:
         name: signatory-dalek crate
         command: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
 version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
-license     = "MIT OR Apache-2.0"
+license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master"

--- a/providers/signatory-dalek/Cargo.toml
+++ b/providers/signatory-dalek/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "signatory-dalek"
 description = "Signatory Ed25519 provider for ed25519-dalek"
 version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
-license     = "MIT OR Apache-2.0"
+license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master/providers/signatory-dalek/"

--- a/providers/signatory-dalek/README.md
+++ b/providers/signatory-dalek/README.md
@@ -23,7 +23,7 @@
 
 ## License
 
-Signatory is distributed under the terms of both the MIT license and the
-Apache License (Version 2.0).
+**Signatory** is distributed under the terms of either the MIT license or the
+Apache License (Version 2.0), at your option.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/providers/signatory-ledger-cosval/Cargo.toml
+++ b/providers/signatory-ledger-cosval/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "signatory-ledger-cosval"
 description = "Signatory provider for ledger cosmos validator app"
 version     = "0.0.1" # Also update html_root_url in lib.rs when bumping this
-license     = "MIT OR Apache-2.0"
+license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master/providers/signatory-ledger-cosval/"

--- a/providers/signatory-ledger-cosval/README.md
+++ b/providers/signatory-ledger-cosval/README.md
@@ -21,7 +21,7 @@
 
 ## License
 
-Signatory is distributed under the terms of both the MIT license and the
-Apache License (Version 2.0).
+**Signatory** is distributed under the terms of either the MIT license or the
+Apache License (Version 2.0), at your option.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/providers/signatory-ring/Cargo.toml
+++ b/providers/signatory-ring/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
 version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
-license     = "MIT OR Apache-2.0"
+license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master/providers/signatory-ring/"

--- a/providers/signatory-ring/README.md
+++ b/providers/signatory-ring/README.md
@@ -24,7 +24,7 @@
 
 ## License
 
-Signatory is distributed under the terms of both the MIT license and the
-Apache License (Version 2.0).
+**Signatory** is distributed under the terms of either the MIT license or the
+Apache License (Version 2.0), at your option.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/providers/signatory-secp256k1/Cargo.toml
+++ b/providers/signatory-secp256k1/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
 version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
-license     = "MIT OR Apache-2.0"
+license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master/providers/signatory-secp256k1/"

--- a/providers/signatory-secp256k1/README.md
+++ b/providers/signatory-secp256k1/README.md
@@ -23,7 +23,7 @@
 
 ## License
 
-Signatory is distributed under the terms of both the MIT license and the
-Apache License (Version 2.0).
+**Signatory** is distributed under the terms of either the MIT license or the
+Apache License (Version 2.0), at your option.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/providers/signatory-sodiumoxide/Cargo.toml
+++ b/providers/signatory-sodiumoxide/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
 version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
-license     = "MIT OR Apache-2.0"
+license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master/providers/signatory-sodiumoxide/"

--- a/providers/signatory-sodiumoxide/README.md
+++ b/providers/signatory-sodiumoxide/README.md
@@ -23,7 +23,7 @@
 
 ## License
 
-Signatory is distributed under the terms of both the MIT license and the
-Apache License (Version 2.0).
+**Signatory** is distributed under the terms of either the MIT license or the
+Apache License (Version 2.0), at your option.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/providers/signatory-yubihsm/Cargo.toml
+++ b/providers/signatory-yubihsm/Cargo.toml
@@ -2,7 +2,7 @@
 name        = "signatory-yubihsm"
 description = "Signatory ECDSA (NIST P256 + secp256k1) and Ed25519 provider for yubihsm-rs"
 version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
-license     = "MIT OR Apache-2.0"
+license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master/providers/signatory-yubihsm/"

--- a/providers/signatory-yubihsm/README.md
+++ b/providers/signatory-yubihsm/README.md
@@ -42,7 +42,7 @@ rustflags = ["-Ctarget-feature=+aes"]
 
 ## License
 
-Signatory is distributed under the terms of both the MIT license and the
-Apache License (Version 2.0).
+**Signatory** is distributed under the terms of either the MIT license or the
+Apache License (Version 2.0), at your option.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -7,16 +7,16 @@
 //!
 //! # Example (with ed25519-dalek)
 //!
-//! ```nobuild
+//! ```
 //! extern crate signatory;
 //! extern crate signatory_dalek; // or another Ed25519 provider
 //!
-//! use signatory::{ed25519, Ed25519Seed, FromEd25519Seed};
+//! use signatory::ed25519;
 //! use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
 //!
 //! // Create a private key (a.k.a. a "seed") and use it to generate a signature
-//! let seed = Ed25519Seed::generate();
-//! let signer = Ed25519Signer::from_seed(seed);
+//! let seed = ed25519::Seed::generate();
+//! let signer = Ed25519Signer::from(&seed);
 //! let msg = "How are you? Fine, thank you.";
 //!
 //! // Sign a message

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,33 +4,117 @@
 //! verifying elliptic curve digital signatures, using either software-based
 //! or hardware-based providers.
 //!
-//! ECDSA ([FIPS 186-4]) and Ed25519 ([RFC 8032]) are the supported digital
-//! signature algorithms.
+//! The following algorithms are supported:
 //!
-//! [FIPS 186-4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
-//! [RFC 8032]: https://tools.ietf.org/html/rfc8032
+//! - [ecdsa]: Elliptic Curve Digital Signature Algorithm ([FIPS 186-4])
+//! - [ed25519]: Edwards Digital Signature Algorithm (EdDSA) instantiated using
+//!   the twisted Edwards form of Curve25519 ([RFC 8032]).
+//!
+//! ## Providers
 //!
 //! There are several backend providers available, which are each available
 //! in their own crates:
 //!
-//! * [signatory-dalek]: Ed25519 signing/verification using the pure-Rust
+//! - [signatory-dalek]: Ed25519 signing/verification using the pure-Rust
 //!   ed25519-dalek crate. This provider is enabled-by-default.
-//! * [signatory-ring]: Ed25519 signing/verification with the *ring*
+//! - [signatory-ring]: Ed25519 signing/verification with the *ring*
 //!   cryptography library.
-//! * [signatory-secp256k1]: ECDSA signing/verification for the secp256k1
+//! - [signatory-secp256k1]: ECDSA signing/verification for the secp256k1
 //!    elliptic curve (commonly used by Bitcoin and other cryptocurrrencies)
 //!    which wraps the libsecp256k1 library from Bitcoin Core.
-//! * [signatory-sodiumoxide]: Ed25519 signing/verification with the
+//! - [signatory-sodiumoxide]: Ed25519 signing/verification with the
 //!   sodiumoxide crate, a Rust wrapper for libsodium (NOTE: requires
 //!   libsodium to be installed on the system)
-//! * [signatory-yubihsm]: Ed25519 signing-only provider using private keys
+//! - [signatory-yubihsm]: Ed25519 signing-only provider using private keys
 //!   stored in a `YubiHSM2` hardware device, via the yubihsm-rs crate.
 //!
+//! ## Signing API
+//!
+//! Signatory provides the following convenience methods for signing. Each of
+//! them dispatches through a trait object for the given trait:
+//!
+//! - [signatory::sign] - sign a byte slice using a given signing provider.
+//!   This method wraps the [Signer] trait and is most useful for computing
+//!   [ed25519] signatures.
+//! - [signatory::sign_digest] - sign the given precomputed digest using the
+//!   given signing provider, a.k.a. Initialize-Update-Finalize (IUF). This
+//!   method wraps the [DigestSigner] trait and is most useful for signing
+//!   large messages in conjunction with hardware-backed signers.
+//! - [signatory::sign_sha256], [signatory::sign_sha384],
+//!   [signatory::sign_sha512] - sign the given message after first computing
+//!   its SHA-2 digest. These methods wrap the [Sha256Signer],
+//!   [Sha384Signer], and [Sha512Signer] traits respectively, and are most
+//!   useful in conjunction with [ecdsa].
+//!
+//! Each of these methods and traits is generic around the signature type.
+//! This makes it important to annotate the particular type of signature
+//! which you would like when using them, e.g.
+//!
+//! ```
+//! use signatory::{self, ed25519};
+//!
+//! let sig: ed25519::Signature = signatory::sign(signer, &msg).unwrap();
+//! ```
+//!
+//! Or use the [turbofish]:
+//!
+//! ```
+//! use signatory::{self, ed25519};
+//!
+//! let sig = signatory::sign::<ed25519::Signature>(signer, &msg).unwrap();
+//! ```
+//!
+//! Alternatively, for Ed25519 signatures, the [ed25519] module provides
+//! methods which operate on concrete Ed25519 types.
+//!
+//! ## Verifier API
+//!
+//! Signatory provides the following convenience methods for verifying
+//! signatures, which map 1:1 to the methods provided for signing:
+//!
+//! * [signatory::verify] - verify a byte slice using a given provider.
+//!   This method wraps the [Verifier] trait and is most useful for verifying
+//!   [ed25519] signatures.
+//! * [signatory::verify_digest] - verify the given precomputed message digest
+//!   against the provided signature, i.e. IUF. This method wraps the
+//!   [DigestVerifier] trait and is most useful for verifying large messages
+//!   in conjunction with hardware-backed signers.
+//! * [signatory::verify_sha256], [signatory::verify_sha384],
+//!   [signatory::verify_sha512] - verify the given message after first
+//!   computing its SHA-2 digest. These methods wrap the [Sha256Verifier],
+//!   [Sha384Verifier], and [Sha512Verifier] traits respectively, and are most
+//!   useful in conjunction with [ecdsa].
+//!
+//! [FIPS 186-4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
+//! [RFC 8032]: https://tools.ietf.org/html/rfc8032
+//! [ecdsa]: https://docs.rs/signatory/latest/signatory/ecdsa/index.html
+//! [ed25519]: https://docs.rs/signatory/latest/signatory/ed25519/index.html
 //! [signatory-dalek]: https://crates.io/crates/signatory-dalek
 //! [signatory-ring]: https://crates.io/crates/signatory-ring
 //! [signatory-secp256k1]: https://crates.io/crates/signatory-secp256k1
 //! [signatory-sodiumoxide]: https://crates.io/crates/signatory-sodiumoxide
 //! [signatory-yubihsm]: https://crates.io/crates/signatory-yubihsm
+//! [signatory::sign]: https://docs.rs/signatory/latest/signatory/fn.sign.html
+//! [signatory::sign_digest]: https://docs.rs/signatory/latest/signatory/fn.sign_digest.html
+//! [signatory::sign_sha256]: https://docs.rs/signatory/latest/signatory/fn.sign_sha256.html
+//! [signatory::sign_sha384]: https://docs.rs/signatory/latest/signatory/fn.sign_sha384.html
+//! [signatory::sign_sha512]: https://docs.rs/signatory/latest/signatory/fn.sign_sha512.html
+//! [Signer]: https://docs.rs/signatory/latest/signatory/trait.Signer.html
+//! [DigestSigner]: https://docs.rs/signatory/latest/signatory/trait.DigestSigner.html
+//! [Sha256Signer]: https://docs.rs/signatory/latest/signatory/trait.Sha256Signer.html
+//! [Sha384Signer]: https://docs.rs/signatory/latest/signatory/trait.Sha384Signer.html
+//! [Sha512Signer]: https://docs.rs/signatory/latest/signatory/trait.Sha512Signer.html
+//! [signatory::verify]: https://docs.rs/signatory/latest/signatory/fn.verify.html
+//! [signatory::verify_digest]: https://docs.rs/signatory/latest/signatory/fn.verify_digest.html
+//! [signatory::verify_sha256]: https://docs.rs/signatory/latest/signatory/fn.verify_sha256.html
+//! [signatory::verify_sha384]: https://docs.rs/signatory/latest/signatory/fn.verify_sha384.html
+//! [signatory::verify_sha512]: https://docs.rs/signatory/latest/signatory/fn.verify_sha512.html
+//! [Verifier]: https://docs.rs/signatory/latest/signatory/trait.Verifier.html
+//! [DigestVerifier]: https://docs.rs/signatory/latest/signatory/trait.DigestVerifier.html
+//! [Sha256Verifier]: https://docs.rs/signatory/latest/signatory/trait.Sha256Verifier.html
+//! [Sha384Verifier]: https://docs.rs/signatory/latest/signatory/trait.Sha384Verifier.html
+//! [Sha512Verifier]: https://docs.rs/signatory/latest/signatory/trait.Sha512Verifier.html
+//! [turbofish]: https://turbo.fish/
 
 #![crate_name = "signatory"]
 #![crate_type = "lib"]

--- a/src/signer/mod.rs
+++ b/src/signer/mod.rs
@@ -13,13 +13,18 @@ pub use self::sha2::*;
 
 /// Trait for all signers which accept a message (byte slice) and produce a
 /// signature of that message using this signer's private key.
+///
+/// Signers should implement this trait for algorithms where there aren't
+/// multiple options for the digest function to be used to hash the message,
+/// e.g. Ed25519.
 pub trait Signer<S: Signature>: Send + Sync {
     /// Sign the given byte slice with this signer's private key, returning a
     /// signature.
     fn sign(&self, msg: &[u8]) -> Result<S, Error>;
 }
 
-/// Sign the given message slice with the given signer (alias for `sign_bytes`)
+/// Sign the given message (byte slice) with the given `Signer`, returning a
+/// signature on success.
 #[inline]
 pub fn sign<S>(signer: &Signer<S>, msg: &[u8]) -> Result<S, Error>
 where

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -18,7 +18,7 @@ pub trait Verifier<S: Signature>: Send + Sync {
     fn verify(&self, msg: &[u8], signature: &S) -> Result<(), Error>;
 }
 
-/// Verify the given message slice with the given verifier (alias for `verify_bytes`)
+/// Verify the given message (byte slice) with the given `Verifier`.
 #[inline]
 pub fn verify<S>(verifier: &Verifier<S>, msg: &[u8], sig: &S) -> Result<(), Error>
 where


### PR DESCRIPTION
- Adds a basic signing/verification API overview to lib.rs.
- Clarify Apache2 OR MIT dual licensing (i.e. either-or, not both)