### PR TITLE
v0.9.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,64 @@
+## [0.9.0] (2018-10-08)
+
+[0.9.0]: https://github.com/tendermint/signatory/pull/114
+
+* [#112](https://github.com/tendermint/signatory/pull/112)
+  Remove redundant "namespacing" from type names.
+
+* [#111](https://github.com/tendermint/signatory/pull/111)
+  Move `curve` module (back) under `ecdsa`.
+
+* [#110](https://github.com/tendermint/signatory/pull/109)
+  signatory-yubihsm: Upgrade to yubihsm 0.18.
+
+* [#109](https://github.com/tendermint/signatory/pull/109)
+  Use `subtle-encoding` crate for constant-time encoding/decoding.
+
+* [#108](https://github.com/tendermint/signatory/pull/108)
+  ECDSA `SecretKey` type and related traits (e.g. `GeneratePkcs8`).
+
+* [#106](https://github.com/tendermint/signatory/pull/106)
+  Properly handle leading zeroes in ASN.1 serialization/parsing.
+
+* [#105](https://github.com/tendermint/signatory/pull/106)
+  signatory-yubihsm: Expose the yubihsm crate as a pub extern.
+
+* [#102](https://github.com/tendermint/signatory/pull/102)
+  encoding: Use 0o600 file mode on Unix.
+
+* [#97](https://github.com/tendermint/signatory/pull/97)
+  Eliminate `ed25519::FromSeed` trait.
+
+* [#94](https://github.com/tendermint/signatory/pull/94)
+  yubihsm: NIST P-384 support.
+
+* [#91](https://github.com/tendermint/signatory/pull/94)
+  ring: NIST P-384 support.
+
+* [#89](https://github.com/tendermint/signatory/pull/89)
+  Add NIST P-384 elliptic curve type (closes #73).
+
+* [#88](https://github.com/tendermint/signatory/pull/88)
+  signatory-yubihsm: Fix ECDSA over secp256k1 signing (closes #87).
+
+* [#80](https://github.com/tendermint/signatory/pull/80)
+  `signatory-ledger-cosval` provider.
+
+* [#79](https://github.com/tendermint/signatory/pull/79)
+  signatory-yubihsm: Normalize secp256k1 signatures to "low S" form.
+
+* [#78](https://github.com/tendermint/signatory/pull/78)
+  signatory-secp256k1: Bump secp256k1 crate dependency to 0.11
+
+* [#76](https://github.com/tendermint/signatory/pull/76)
+  Unify verification API under the `Verifier` trait.
+
+* [#74](https://github.com/tendermint/signatory/pull/74)
+  encoding: Add encoding module with hex and Base64 support.
+
+* [#70](https://github.com/tendermint/signatory/pull/70)
+  Unify signing API under the `Signer` trait.
+
 ## [0.8.0] (2018-08-19)
 
 [0.8.0]: https://github.com/tendermint/signatory/compare/v0.7.0...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"

--- a/providers/signatory-dalek/Cargo.toml
+++ b/providers/signatory-dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-dalek"
 description = "Signatory Ed25519 provider for ed25519-dalek"
-version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -19,7 +19,7 @@ ed25519-dalek = { version = "0.8", default-features = false, features = ["sha2"]
 sha2 = "0.7"
 
 [dependencies.signatory]
-version = "0.9.0-alpha3"
+version = "0.9"
 default-features = false
 features = ["digest", "ed25519", "generic-array", "sha2", "test-vectors"]
 path = "../.."

--- a/providers/signatory-dalek/src/lib.rs
+++ b/providers/signatory-dalek/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-dalek/0.9.0-alpha2"
+    html_root_url = "https://docs.rs/signatory-dalek/0.9.0"
 )]
 
 extern crate digest;

--- a/providers/signatory-ledger-cosval/Cargo.toml
+++ b/providers/signatory-ledger-cosval/Cargo.toml
@@ -1,26 +1,25 @@
 [package]
 name        = "signatory-ledger-cosval"
 description = "Signatory provider for ledger cosmos validator app"
-version     = "0.0.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/tendermint/signatory"
 repository  = "https://github.com/tendermint/signatory/tree/master/providers/signatory-ledger-cosval/"
 readme      = "README.md"
 categories  = ["authentication", "cryptography", "no-std"]
-keywords    = ["cryptography", "tendermint", "cosmos", "ecdsa", "signatures", "validator"]
+keywords    = ["cosmos", "ed25519", "signatures", "tendermint", "validator"]
 
 [badges]
 circle-ci = { repository = "tendermint/signatory" }
 
 [dependencies]
 lazy_static = "1"
-ledger-cosmos ="0.0.6"
-#ledger-cosmos-rs = { path = "../../../ledger-cosmos-rs" }
-libc = "0.2.43"
+ledger-cosmos = "0.0.6"
+libc = "0.2"
 
 [dependencies.signatory]
-version = "0.9.0-alpha3"
+version = "0.9"
 features = ["digest", "ed25519", "generic-array", "test-vectors"]
 path = "../.."
 

--- a/providers/signatory-ledger-cosval/src/lib.rs
+++ b/providers/signatory-ledger-cosval/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ledger-cosval/0.0.1"
+    html_root_url = "https://docs.rs/signatory-ledger-cosval/0.9.0"
 )]
 
 extern crate ledger_cosmos;

--- a/providers/signatory-ring/Cargo.toml
+++ b/providers/signatory-ring/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
-version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -18,7 +18,7 @@ ring = "0.13"
 untrusted = "0.6"
 
 [dependencies.signatory]
-version = "0.9.0-alpha3"
+version = "0.9"
 default-features = false
 features = ["pkcs8", "test-vectors"]
 path = "../.."

--- a/providers/signatory-ring/src/lib.rs
+++ b/providers/signatory-ring/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ring/0.9.0-alpha2"
+    html_root_url = "https://docs.rs/signatory-ring/0.9.0"
 )]
 
 extern crate ring;

--- a/providers/signatory-secp256k1/Cargo.toml
+++ b/providers/signatory-secp256k1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
-version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -18,7 +18,7 @@ lazy_static = "1"
 secp256k1 = "0.11"
 
 [dependencies.signatory]
-version = "0.9.0-alpha3"
+version = "0.9"
 features = ["digest", "ecdsa", "sha2", "test-vectors"]
 path = "../.."
 

--- a/providers/signatory-secp256k1/src/lib.rs
+++ b/providers/signatory-secp256k1/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-secp256k1/0.9.0-alpha2"
+    html_root_url = "https://docs.rs/signatory-secp256k1/0.9.0"
 )]
 
 #[macro_use]

--- a/providers/signatory-sodiumoxide/Cargo.toml
+++ b/providers/signatory-sodiumoxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
-version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -17,7 +17,7 @@ circle-ci = { repository = "tendermint/signatory" }
 sodiumoxide = "0.1"
 
 [dependencies.signatory]
-version = "0.9.0-alpha3"
+version = "0.9"
 features = ["ed25519"]
 path = "../.."
 

--- a/providers/signatory-sodiumoxide/src/lib.rs
+++ b/providers/signatory-sodiumoxide/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.9.0-alpha2"
+    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.9.0"
 )]
 
 #[cfg_attr(test, macro_use)]

--- a/providers/signatory-yubihsm/Cargo.toml
+++ b/providers/signatory-yubihsm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-yubihsm"
 description = "Signatory ECDSA (NIST P256 + secp256k1) and Ed25519 provider for yubihsm-rs"
-version     = "0.9.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -19,13 +19,13 @@ secp256k1 = { version = "0.11", optional = true }
 yubihsm = { version = "0.18", default-features = false, features = ["passwords"] }
 
 [dependencies.signatory]
-version = "0.9.0-alpha3"
+version = "0.9"
 features = ["digest", "ecdsa", "ed25519",  "sha2"]
 path = "../.."
 
 [dev-dependencies]
-signatory-ring = { version = "0.9.0-alpha3", path = "../signatory-ring" }
-signatory-secp256k1 = { version = "0.9.0-alpha3", path = "../signatory-secp256k1" }
+signatory-ring = { version = "0.9", path = "../signatory-ring" }
+signatory-secp256k1 = { version = "0.9", path = "../signatory-secp256k1" }
 lazy_static = "1"
 
 [features]

--- a/providers/signatory-yubihsm/src/lib.rs
+++ b/providers/signatory-yubihsm/src/lib.rs
@@ -10,7 +10,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-yubihsm/0.9.0-alpha2"
+    html_root_url = "https://docs.rs/signatory-yubihsm/0.9.0"
 )]
 
 #[cfg(feature = "secp256k1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.9.0-alpha2"
+    html_root_url = "https://docs.rs/signatory/0.9.0"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
[Diff from 0.8](https://github.com/tendermint/signatory/compare/v0.8.0...v0.9.0)

* #112 Remove redundant "namespacing" from type names.
* #111 Move `curve` module (back) under `ecdsa`.
* #110 signatory-yubihsm: Upgrade to yubihsm 0.18.
* #109 Use `subtle-encoding` crate for constant-time encoding/decoding.
* #108 ECDSA `SecretKey` type and related traits (e.g. `GeneratePkcs8`).
* #106 Properly handle leading zeroes in ASN.1 serialization/parsing.
* #105 signatory-yubihsm: Expose the yubihsm crate as a pub extern.
* #102 encoding: Use 0o600 file mode on Unix.
* #97 Eliminate `ed25519::FromSeed` trait.
* #94 yubihsm: NIST P-384 support.
* #91 ring: NIST P-384 support.
* #89 Add NIST P-384 elliptic curve type (closes #73).
* #88 signatory-yubihsm: Fix ECDSA over secp256k1 signing (closes #87).
* #80 `signatory-ledger-cosval` provider.
* #79 signatory-yubihsm: Normalize secp256k1 signatures to "low S" form.
* #78 signatory-secp256k1: Bump secp256k1 crate dependency to 0.11
* #76 Unify verification API under the `Verifier` trait.
* #74 encoding: Add encoding module with hex and Base64 support.
* #70 Unify signing API under the `Signer` trait.