### PR TITLE
Cargo.toml: Fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,4 @@ debug-assertions = false
 codegen-units = 1
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["ecdsa", "ed25519", "pkcs8"]


### PR DESCRIPTION
Currently failing since the `nightly` feature is enabled:

https://docs.rs/crate/signatory/0.9.0/builds/120117