### PR TITLE
More documentation fixups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,4 @@ debug-assertions = false
 codegen-units = 1
 
 [package.metadata.docs.rs]
-features = ["ecdsa", "ed25519", "pkcs8"]
+features = ["digest", "ecdsa", "ed25519", "pkcs8", "sha2"]

--- a/providers/signatory-dalek/src/lib.rs
+++ b/providers/signatory-dalek/src/lib.rs
@@ -1,4 +1,9 @@
-//! Signatory Ed25519 provider for ed25519-dalek
+//! Signatory Ed25519 provider for the [ed25519-dalek] crate.
+//!
+//! For a usage example, see the toplevel Signatory docs:
+//! <https://docs.rs/signatory/latest/signatory/ed25519/index.html>
+//!
+//! [ed25519-dalek]: https://github.com/dalek-cryptography/ed25519-dalek
 
 #![crate_name = "signatory_dalek"]
 #![crate_type = "lib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,11 @@
 //! [RFC 8032]: https://tools.ietf.org/html/rfc8032
 //! [ecdsa]: https://docs.rs/signatory/latest/signatory/ecdsa/index.html
 //! [ed25519]: https://docs.rs/signatory/latest/signatory/ed25519/index.html
-//! [signatory-dalek]: https://crates.io/crates/signatory-dalek
-//! [signatory-ring]: https://crates.io/crates/signatory-ring
-//! [signatory-secp256k1]: https://crates.io/crates/signatory-secp256k1
-//! [signatory-sodiumoxide]: https://crates.io/crates/signatory-sodiumoxide
-//! [signatory-yubihsm]: https://crates.io/crates/signatory-yubihsm
+//! [signatory-dalek]: https://docs.rs/crate/signatory-dalek/
+//! [signatory-ring]: https://docs.rs/crate/signatory-ring/
+//! [signatory-secp256k1]: https://docs.rs/crate/signatory-secp256k1/
+//! [signatory-sodiumoxide]: https://docs.rs/crate/signatory-sodiumoxide/
+//! [signatory-yubihsm]:  https://docs.rs/crate/signatory-yubihsm/
 //! [signatory::sign]: https://docs.rs/signatory/latest/signatory/fn.sign.html
 //! [signatory::sign_digest]: https://docs.rs/signatory/latest/signatory/fn.sign_digest.html
 //! [signatory::sign_sha256]: https://docs.rs/signatory/latest/signatory/fn.sign_sha256.html

--- a/src/signer/digest.rs
+++ b/src/signer/digest.rs
@@ -1,4 +1,6 @@
 //! Prehash (a.k.a. "IUF") signing support using the `Digest` trait
+//!
+//! Enable Signatory's `digest` cargo feature to enable this trait.
 
 use digest::Digest;
 

--- a/src/verifier/digest.rs
+++ b/src/verifier/digest.rs
@@ -1,4 +1,6 @@
-//! Prehash (a.k.a. "IUF") verifying support using the `Digest` trait
+//! Prehash (a.k.a. "IUF") verifying support using the `Digest` trait.
+//!
+//! Enable Signatory's `digest` cargo feature to enable this trait.
 
 use digest::Digest;
 


### PR DESCRIPTION
- Enable more cargo features (`digest`, `sha2`) on docs.rs
- Link to `docs.rs` for provider crates
- Add link to `signatory-dalek` example