### PR TITLE
Fix unused import on Windows (closes #121)

### DIFF
--- a/src/encoding/encode.rs
+++ b/src/encoding/encode.rs
@@ -5,6 +5,7 @@ use std::{fs::OpenOptions, os::unix::fs::OpenOptionsExt};
 use subtle_encoding::Encoding;
 use zeroize::secure_zero_memory;
 
+#[cfg(unix)]
 use super::FILE_MODE;
 use error::Error;
 use prelude::*;


### PR DESCRIPTION
Unfortunately we don't have Appveyor set up, so not sure if this is actually fixed.