### PR TITLE
v0.9.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [0.9.3] (2018-10-09)
+
+[0.9.3]: https://github.com/tendermint/signatory/pull/124
+
+* [#123](https://github.com/tendermint/signatory/pull/123)
+  Upgrade to subtle-encoding v0.2.
+
+* [#122](https://github.com/tendermint/signatory/pull/122)
+  Fix unused import on Windows (closes #121).
+
 ## [0.9.2] (2018-10-08)
 
 [0.9.2]: https://github.com/tendermint/signatory/pull/118

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.9.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.3" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.9.2"
+    html_root_url = "https://docs.rs/signatory/0.9.3"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
[Diff from 0.9.2](https://github.com/tendermint/signatory/compare/v0.9.2...v0.9.3)

* #123 Upgrade to `subtle-encoding` v0.2.
 * #122 Fix unused import on Windows (closes #121).