### PR TITLE
v0.9.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.9.4] (2018-10-10)
+
+[0.9.4]: https://github.com/tendermint/signatory/pull/126
+
+* [#125](https://github.com/tendermint/signatory/pull/125)
+  pkcs8: Properly gate `FILE_MODE` on Windows.
+
 ## [0.9.3] (2018-10-09)
 
 [0.9.3]: https://github.com/tendermint/signatory/pull/124

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.9.3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.9.4" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,9 @@
 //! - [signatory-sodiumoxide]: Ed25519 signing/verification with the
 //!   sodiumoxide crate, a Rust wrapper for libsodium (NOTE: requires
 //!   libsodium to be installed on the system)
-//! - [signatory-yubihsm]: Ed25519 signing-only provider using private keys
-//!   stored in a `YubiHSM2` hardware device, via the yubihsm-rs crate.
+//! - [signatory-yubihsm]: ECDSA and Ed25519 signing provider which uses
+//!   private keys stored in a `YubiHSM2` hardware device, via the
+//!   `yubihsm-rs` crate.
 //!
 //! ## Signing API
 //!


### PR DESCRIPTION
[Diff from v0.9.3]: https://github.com/tendermint/signatory/compare/v0.9.3...v0.9.4

- #125 pkcs8: Properly gate `FILE_MODE` on Windows.