### PR TITLE
Upgrade to digest 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ autobenches = false
 circle-ci = { repository = "tendermint/signatory" }
 
 [dependencies]
-digest = { version = "0.7", optional = true, default-features = false }
-generic-array = { version = "0.9", optional = true }
+digest = { version = "0.8", optional = true, default-features = false }
+generic-array = { version = "0.12", optional = true }
 rand = { version = "0.5", optional = true, default-features = false }
-sha2 = { version = "0.7", optional = true, default-features = false }
+sha2 = { version = "0.8", optional = true, default-features = false }
 subtle-encoding = { version = "0.2", optional = true, default-features = false, features = ["base64", "hex"] }
 zeroize = { version = "0.4", optional = true }
 

--- a/providers/signatory-dalek/Cargo.toml
+++ b/providers/signatory-dalek/Cargo.toml
@@ -15,8 +15,8 @@ circle-ci = { repository = "tendermint/signatory" }
 
 [dependencies]
 digest = { version = "0.7", default-features = false }
-ed25519-dalek = { version = "0.8", default-features = false, features = ["sha2"] }
-sha2 = "0.7"
+ed25519-dalek = { version = "0.8", default-features = false }
+sha2 = { version =  "0.7", default-features = false }
 
 [dependencies.signatory]
 version = "0.9"

--- a/providers/signatory-dalek/src/lib.rs
+++ b/providers/signatory-dalek/src/lib.rs
@@ -21,6 +21,9 @@ extern crate sha2;
 #[cfg_attr(test, macro_use)]
 extern crate signatory;
 
+// TEMPORARILY DISABLED UNTIL DALEK IS UPDATED TO DIGEST 0.8
+// See: https://github.com/dalek-cryptography/curve25519-dalek/pull/201
+#[cfg(feature = "digest-0.8")]
 use digest::Digest;
 use ed25519_dalek::{Keypair, SecretKey};
 use sha2::Sha512;
@@ -28,9 +31,12 @@ use sha2::Sha512;
 use signatory::{
     ed25519,
     error::{Error, ErrorKind},
-    generic_array::typenum::U64,
-    DigestSigner, DigestVerifier, PublicKeyed, Signature, Signer, Verifier,
+    PublicKeyed, Signature, Signer, Verifier,
 };
+// TEMPORARILY DISABLED UNTIL DALEK IS UPDATED TO DIGEST 0.8
+// See: https://github.com/dalek-cryptography/curve25519-dalek/pull/201
+#[cfg(feature = "digest-0.8")]
+use signatory::{generic_array::typenum::U64, DigestSigner, DigestVerifier};
 
 /// Ed25519 signature provider for ed25519-dalek
 pub struct Ed25519Signer(Keypair);
@@ -72,6 +78,9 @@ impl PublicKeyed<ed25519::PublicKey> for Ed25519PhSigner {
 }
 
 // TODO: tests!
+// TEMPORARILY DISABLED UNTIL DALEK IS UPDATED TO DIGEST 0.8
+// See: https://github.com/dalek-cryptography/curve25519-dalek/pull/201
+#[cfg(feature = "digest-0.8")]
 impl<D> DigestSigner<D, ed25519::Signature> for Ed25519PhSigner
 where
     D: Digest<OutputSize = U64> + Default,
@@ -117,6 +126,9 @@ impl<'a> From<&'a ed25519::PublicKey> for Ed25519PhVerifier {
 }
 
 // TODO: tests!
+// TEMPORARILY DISABLED UNTIL DALEK IS UPDATED TO DIGEST 0.8
+// See: https://github.com/dalek-cryptography/curve25519-dalek/pull/201
+#[cfg(feature = "digest-0.8")]
 impl<D> DigestVerifier<D, ed25519::Signature> for Ed25519PhVerifier
 where
     D: Digest<OutputSize = U64> + Default,

--- a/providers/signatory-yubihsm/Cargo.toml
+++ b/providers/signatory-yubihsm/Cargo.toml
@@ -16,7 +16,7 @@ circle-ci = { repository = "tendermint/signatory" }
 [dependencies]
 lazy_static = "1"
 secp256k1 = { version = "0.11", optional = true }
-yubihsm = { version = "0.18", default-features = false, features = ["passwords"] }
+yubihsm = { version = "0.19", default-features = false, features = ["passwords"] }
 
 [dependencies.signatory]
 version = "0.9"

--- a/src/signer/sha2.rs
+++ b/src/signer/sha2.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "digest", feature = "sha2"))]
-use digest::Input;
+use digest::Digest;
 #[cfg(all(feature = "digest", feature = "sha2"))]
 use sha2::{Sha256, Sha384, Sha512};
 
@@ -26,9 +26,7 @@ where
     T: DigestSigner<Sha256, S>,
 {
     fn sign_sha256(&self, msg: &[u8]) -> Result<S, Error> {
-        let mut sha256 = Sha256::default();
-        sha256.process(msg);
-        self.sign(sha256)
+        self.sign(Sha256::new().chain(msg))
     }
 }
 
@@ -48,9 +46,7 @@ where
     T: DigestSigner<Sha384, S>,
 {
     fn sign_sha384(&self, msg: &[u8]) -> Result<S, Error> {
-        let mut sha384 = Sha384::default();
-        sha384.process(msg);
-        self.sign(sha384)
+        self.sign(Sha384::new().chain(msg))
     }
 }
 
@@ -70,9 +66,7 @@ where
     T: DigestSigner<Sha512, S>,
 {
     fn sign_sha512(&self, msg: &[u8]) -> Result<S, Error> {
-        let mut sha512 = Sha512::default();
-        sha512.process(msg);
-        self.sign(sha512)
+        self.sign(Sha512::new().chain(msg))
     }
 }
 

--- a/src/verifier/sha2.rs
+++ b/src/verifier/sha2.rs
@@ -1,5 +1,5 @@
 #[cfg(all(feature = "digest", feature = "sha2"))]
-use digest::Input;
+use digest::Digest;
 #[cfg(all(feature = "digest", feature = "sha2"))]
 use sha2::{Sha256, Sha384, Sha512};
 
@@ -25,9 +25,7 @@ where
     T: DigestVerifier<Sha256, S>,
 {
     fn verify_sha256(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
-        let mut sha256 = Sha256::default();
-        sha256.process(msg);
-        self.verify(sha256, signature)
+        self.verify(Sha256::new().chain(msg), signature)
     }
 }
 
@@ -47,9 +45,7 @@ where
     T: DigestVerifier<Sha384, S>,
 {
     fn verify_sha384(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
-        let mut sha384 = Sha384::default();
-        sha384.process(msg);
-        self.verify(sha384, signature)
+        self.verify(Sha384::new().chain(msg), signature)
     }
 }
 
@@ -69,9 +65,7 @@ where
     T: DigestVerifier<Sha512, S>,
 {
     fn verify_sha512(&self, msg: &[u8], signature: &S) -> Result<(), Error> {
-        let mut sha512 = Sha512::default();
-        sha512.process(msg);
-        self.verify(sha512, signature)
+        self.verify(Sha512::new().chain(msg), signature)
     }
 }
 


### PR DESCRIPTION
- Upgrades to yubihsm 0.19
- Temporarily disables dalek's DigestSigner/DigestVerifier until it's updated to digest 0.8. See:
  https://github.com/dalek-cryptography/curve25519-dalek/pull/201