### PR TITLE
Upgrade to subtle-encoding v0.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2
 jobs:
   build:
     docker:
-    - image: iqlusion/rust-ci:20180921.0 # bump cache keys when modifying this
+    - image: iqlusion/tmkms:2018-11-27-v4 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-20180921.0 # bump save_cache key below too
+        key: cache-2018-11-27-v4 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -115,7 +115,7 @@ jobs:
           cargo audit --version
           cargo audit
     - save_cache:
-        key: cache-20180921.0 # bump restore_cache key above too
+        key: cache-2018-11-27-v4 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ digest = { version = "0.8", optional = true, default-features = false }
 generic-array = { version = "0.12", optional = true }
 rand = { version = "0.5", optional = true, default-features = false }
 sha2 = { version = "0.8", optional = true, default-features = false }
-subtle-encoding = { version = "0.2", optional = true, default-features = false, features = ["base64", "hex"] }
+subtle-encoding = { version = "0.3", optional = true, default-features = false, features = ["base64", "hex"] }
 zeroize = { version = "0.4", optional = true }
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -185,10 +185,12 @@ impl From<io::Error> for Error {
 impl From<subtle_encoding::Error> for Error {
     fn from(err: subtle_encoding::Error) -> Self {
         match err {
+            subtle_encoding::Error::ChecksumInvalid => err!(ParseError, "invalid checksum"),
             subtle_encoding::Error::EncodingInvalid => err!(ParseError, "invalid encoding"),
             subtle_encoding::Error::LengthInvalid => err!(ParseError, "invalid length"),
             #[cfg(feature = "std")]
             subtle_encoding::Error::IoError => err!(Io, &err.to_string()),
+            subtle_encoding::Error::PaddingInvalid => err!(ParseError, "invalid padding"),
         }
     }
 }


### PR DESCRIPTION
Fixes critical encode/decode bug in `release` builds