### PR TITLE
v0.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [0.11.0] (2019-02-12)
+
+- signatory-yubihsm: Update `yubihsm` crate to v0.20 ([#138])
+- signatory-dalek: Update `ed25519-dalek` crate to 1.0.0-pre.1 ([#137])
+- signatory-ring: Update `ring` crate to 0.14 ([#137])
+- signatory-sodiumoxide: Update `sodiumoxide` crate to 0.2 ([#137]) 
+- signatory-secp256k1: Update `secp256k1` crate to 0.12 ([#137])
+- Upgrade to Rust 2018 edition ([#137])
+- signatory-ledger-cosval: Upgrade ledger provider to validator app 0.2.1 ([#135])
+
 ## [0.10.1] (2018-11-27)
 
 - Upgrade to subtle-encoding v0.3.0 (#132)
@@ -124,6 +134,10 @@
 
 - Initial release
 
+[0.11.0]: https://github.com/tendermint/signatory/pull/139
+[#138]: https://github.com/tendermint/signatory/pull/138
+[#137]: https://github.com/tendermint/signatory/pull/137
+[#135]: https://github.com/tendermint/signatory/pull/135
 [0.10.1]: https://github.com/tendermint/signatory/pull/134
 [0.10.0]: https://github.com/tendermint/signatory/pull/131
 [0.9.4]: https://github.com/tendermint/signatory/pull/126

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.10.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Signatory exposes a thread-and-object-safe API for creating digital signatures
 which allows several signature providers to be compiled-in and available with
 specific providers selected at runtime.
 
+## Requirements
+
+All Signatory providers require Rust 1.31+.
+
 ## Provider Support
 
 Signatory includes the following providers, which are each packaged into their

--- a/signatory-dalek/Cargo.toml
+++ b/signatory-dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-dalek"
 description = "Signatory Ed25519 provider for ed25519-dalek"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -20,7 +20,7 @@ ed25519-dalek = { version = "1.0.0-pre.1", default-features = false }
 sha2 = { version =  "0.8", default-features = false }
 
 [dependencies.signatory]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = ["digest", "ed25519", "generic-array", "sha2", "test-vectors"]
 path = ".."

--- a/signatory-dalek/src/lib.rs
+++ b/signatory-dalek/src/lib.rs
@@ -10,7 +10,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-dalek/0.10.0"
+    html_root_url = "https://docs.rs/signatory-dalek/0.11.0"
 )]
 
 #[cfg(test)]

--- a/signatory-ledger-cosval/Cargo.toml
+++ b/signatory-ledger-cosval/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ledger-cosval"
 description = "Signatory provider for ledger cosmos validator app"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0-pre" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -20,7 +20,7 @@ ledger-cosmos = "0.2.0"
 libc = "0.2"
 
 [dependencies.signatory]
-version = "0.10"
+version = "0.11"
 features = ["digest", "ed25519", "generic-array", "test-vectors"]
 path = ".."
 

--- a/signatory-ledger-cosval/src/lib.rs
+++ b/signatory-ledger-cosval/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ledger-cosval/0.10.0"
+    html_root_url = "https://docs.rs/signatory-ledger-cosval/0.11.0-pre"
 )]
 
 use std::sync::{Arc, Mutex};

--- a/signatory-ring/Cargo.toml
+++ b/signatory-ring/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -19,7 +19,7 @@ ring = "0.14"
 untrusted = "0.6"
 
 [dependencies.signatory]
-version = "0.10"
+version = "0.11"
 default-features = false
 features = ["pkcs8", "test-vectors"]
 path = ".."

--- a/signatory-ring/src/lib.rs
+++ b/signatory-ring/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ring/0.10.0"
+    html_root_url = "https://docs.rs/signatory-ring/0.11.0"
 )]
 
 #[cfg(test)]

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -18,7 +18,7 @@ circle-ci = { repository = "tendermint/signatory" }
 secp256k1 = "0.12"
 
 [dependencies.signatory]
-version = "0.10"
+version = "0.11"
 features = ["digest", "ecdsa", "sha2", "test-vectors"]
 path = ".."
 

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-secp256k1/0.10.0"
+    html_root_url = "https://docs.rs/signatory-secp256k1/0.11.0"
 )]
 
 use secp256k1::{self, Secp256k1, SignOnly, VerifyOnly};

--- a/signatory-sodiumoxide/Cargo.toml
+++ b/signatory-sodiumoxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -18,7 +18,7 @@ circle-ci = { repository = "tendermint/signatory" }
 sodiumoxide = "0.2"
 
 [dependencies.signatory]
-version = "0.10"
+version = "0.11"
 features = ["ed25519", "test-vectors"]
 path = ".."
 

--- a/signatory-sodiumoxide/src/lib.rs
+++ b/signatory-sodiumoxide/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.10.0"
+    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.11.0"
 )]
 
 #[cfg(test)]

--- a/signatory-yubihsm/Cargo.toml
+++ b/signatory-yubihsm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-yubihsm"
 description = "Signatory ECDSA (NIST P256 + secp256k1) and Ed25519 provider for yubihsm-rs"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -18,14 +18,14 @@ secp256k1 = { version = "0.12", optional = true }
 yubihsm = { version = "0.20", default-features = false, features = ["passwords"] }
 
 [dependencies.signatory]
-version = "0.10"
+version = "0.11"
 features = ["digest", "ecdsa", "ed25519", "sha2"]
 path = ".."
 
 [dev-dependencies]
 lazy_static = "1"
-signatory-ring = { version = "0.10", path = "../signatory-ring" }
-signatory-secp256k1 = { version = "0.10", path = "../signatory-secp256k1" }
+signatory-ring = { version = "0.11", path = "../signatory-ring" }
+signatory-secp256k1 = { version = "0.11", path = "../signatory-secp256k1" }
 
 [features]
 default = ["http", "ecdsa", "ed25519"]

--- a/signatory-yubihsm/src/lib.rs
+++ b/signatory-yubihsm/src/lib.rs
@@ -8,7 +8,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-yubihsm/0.10.0"
+    html_root_url = "https://docs.rs/signatory-yubihsm/0.11.0"
 )]
 
 pub extern crate signatory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.10.1"
+    html_root_url = "https://docs.rs/signatory/0.11.0"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
- signatory-yubihsm: Update `yubihsm` crate to v0.20 (#138)
- signatory-dalek: Update `ed25519-dalek` crate to 1.0.0-pre.1 (#137)
- signatory-ring: Update `ring` crate to 0.14 (#137)
- signatory-secp256k1: Update `secp256k1` crate to 0.12 (#137)
- signatory-sodiumoxide: Update `sodiumoxide` crate to 0.2 (#137) 
- Upgrade to Rust 2018 edition (#137)
- signatory-ledger-cosval: Upgrade ledger provider to validator app 0.2.1 (#135)