### PR TITLE
Simplify trait bounds for Copy impl on ECDSA curve point types

### DIFF
--- a/src/ecdsa/curve/point.rs
+++ b/src/ecdsa/curve/point.rs
@@ -61,7 +61,7 @@ impl<C: WeierstrassCurve> AsRef<[u8]> for CompressedCurvePoint<C> {
 impl<C> Copy for CompressedCurvePoint<C>
 where
     C: WeierstrassCurve,
-    <<C as WeierstrassCurve>::CompressedPointSize as ArrayLength<u8>>::ArrayType: Copy,
+    <C::CompressedPointSize as ArrayLength<u8>>::ArrayType: Copy,
 {
 }
 
@@ -124,7 +124,7 @@ impl<C: WeierstrassCurve> AsRef<[u8]> for UncompressedCurvePoint<C> {
 impl<C> Copy for UncompressedCurvePoint<C>
 where
     C: WeierstrassCurve,
-    <<C as WeierstrassCurve>::UncompressedPointSize as ArrayLength<u8>>::ArrayType: Copy,
+    <C::UncompressedPointSize as ArrayLength<u8>>::ArrayType: Copy,
 {
 }
 


### PR DESCRIPTION
This was a copypasta rustc suggestion, however it's also highly redundant as these precise bounds are explicitly specified.