### PR TITLE
fix: Missing TrailingWhitespace type-case in subtle-encoding error conversion

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -188,9 +188,10 @@ impl From<subtle_encoding::Error> for Error {
             subtle_encoding::Error::ChecksumInvalid => err!(ParseError, "invalid checksum"),
             subtle_encoding::Error::EncodingInvalid => err!(ParseError, "invalid encoding"),
             subtle_encoding::Error::LengthInvalid => err!(ParseError, "invalid length"),
+            subtle_encoding::Error::PaddingInvalid => err!(ParseError, "invalid padding"),
+            subtle_encoding::Error::TrailingWhitespace => err!(ParseError, "trailing whitestpace"),
             #[cfg(feature = "std")]
             subtle_encoding::Error::IoError => err!(Io, &err.to_string()),
-            subtle_encoding::Error::PaddingInvalid => err!(ParseError, "invalid padding"),
         }
     }
 }


### PR DESCRIPTION
fixes missing `TrailingWhitespace` type-case
```
$ cargo build
    Updating crates.io index
   Compiling proc-macro2 v0.4.27
   Compiling unicode-xid v0.1.0
   Compiling syn v0.15.29
   Compiling failure_derive v0.1.5
   Compiling libc v0.2.50
   Compiling failure v0.1.5
   Compiling zeroize v0.5.2
   Compiling rand_core v0.4.0
   Compiling rand_os v0.1.3
   Compiling quote v0.6.11
   Compiling synstructure v0.10.1
   Compiling subtle-encoding v0.3.3
   Compiling signatory v0.11.2 (/Users/saadtalaat/C1/work/signatory)
error[E0004]: non-exhaustive patterns: `TrailingWhitespace` not covered
   --> src/error.rs:187:15
    |
187 |         match err {
    |               ^^^ pattern `TrailingWhitespace` not covered

error: aborting due to previous error

For more information about this error, try `rustc --explain E0004`.
error: Could not compile `signatory`.

To learn more, run the command again with --verbose.
```