### PR TITLE
v0.11.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.11.3] (2019-03-13)
+
+- Fix Missing TrailingWhitespace type-case in subtle-encoding error conversion ([#149])
+
 ## [0.11.2] (2019-03-09)
 
 - ecdsa: impl `PartialOrd` + `Ord` for PublicKeys ([#147])
@@ -144,6 +148,8 @@
 
 - Initial release
 
+[0.11.3]: https://github.com/tendermint/signatory/pull/150
+[#149]: https://github.com/tendermint/signatory/pull/149
 [0.11.2]: https://github.com/tendermint/signatory/pull/148
 [#147]: https://github.com/tendermint/signatory/pull/147
 [#146]: https://github.com/tendermint/signatory/pull/146

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.11.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.3" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -20,7 +20,7 @@ digest = { version = "0.8", optional = true, default-features = false }
 generic-array = { version = "0.12", optional = true }
 rand_os = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.8", optional = true, default-features = false }
-subtle-encoding = { version = "0.3", optional = true, default-features = false, features = ["base64", "hex"] }
+subtle-encoding = { version = "0.3.3", optional = true, default-features = false, features = ["base64", "hex"] }
 zeroize = { version = "0.5", optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/master/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.11.2"
+    html_root_url = "https://docs.rs/signatory/0.11.3"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
- Fix Missing TrailingWhitespace type-case in subtle-encoding error conversion (#149)