### PR TITLE
v0.11.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.11.4] (2019-05-20)
+
+- Support stable `alloc` API ([#154])
+- Upgrade to zeroize 0.8 ([#153])
+
 ## [0.11.3] (2019-03-13)
 
 - Fix Missing TrailingWhitespace type-case in subtle-encoding error conversion ([#149])
@@ -148,6 +153,9 @@
 
 - Initial release
 
+[0.11.4]: https://github.com/tendermint/signatory/pull/155
+[#154]: https://github.com/tendermint/signatory/pull/154
+[#153]: https://github.com/tendermint/signatory/pull/153
 [0.11.3]: https://github.com/tendermint/signatory/pull/150
 [#149]: https://github.com/tendermint/signatory/pull/149
 [0.11.2]: https://github.com/tendermint/signatory/pull/148

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.11.3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.4" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@
 )]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.11.3"
+    html_root_url = "https://docs.rs/signatory/0.11.4"
 )]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]


### PR DESCRIPTION
- Support stable `alloc` API (#154)
- Upgrade to zeroize 0.8 (#153)