### PR TITLE
Switch from rand_os to getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ circle-ci = { repository = "tendermint/signatory" }
 [dependencies]
 digest = { version = "0.8", optional = true, default-features = false }
 generic-array = { version = "0.12", optional = true }
-rand_os = { version = "0.1", optional = true, default-features = false }
+getrandom = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.8", optional = true, default-features = false }
 zeroize = { version = "0.8", optional = true }
 
@@ -30,7 +30,7 @@ features = ["base64", "hex"]
 
 [features]
 alloc = []
-default = ["encoding", "rand_os", "std"]
+default = ["encoding", "getrandom", "std"]
 ecdsa = ["generic-array", "zeroize"]
 ed25519 = ["zeroize"]
 encoding = ["subtle-encoding", "zeroize"]

--- a/src/ecdsa/secret_key.rs
+++ b/src/ecdsa/secret_key.rs
@@ -9,11 +9,8 @@ use crate::error::Error;
 #[cfg(all(feature = "alloc", feature = "encoding"))]
 use crate::prelude::*;
 use generic_array::{typenum::Unsigned, GenericArray};
-#[cfg(all(feature = "rand_os", feature = "std"))]
-use rand_os::{
-    rand_core::{CryptoRng, RngCore},
-    OsRng,
-};
+#[cfg(feature = "getrandom")]
+use getrandom::getrandom;
 #[cfg(feature = "encoding")]
 use subtle_encoding::Encoding;
 use zeroize::Zeroize;
@@ -58,21 +55,10 @@ where
 
     /// Generate a new ECDSA secret key using the operating system's
     /// cryptographically secure random number generator
-    #[cfg(feature = "rand_os")]
+    #[cfg(feature = "getrandom")]
     pub fn generate() -> Self {
-        let mut csprng = OsRng::new().expect("RNG initialization failure!");
-        Self::generate_from_rng(&mut csprng)
-    }
-
-    /// Generate a new ECDSA secret key using the provided random number generator
-    #[cfg(feature = "rand_os")]
-    pub fn generate_from_rng<R>(csprng: &mut R) -> Self
-    where
-        R: CryptoRng + RngCore,
-    {
         let mut bytes = GenericArray::default();
-        csprng.fill_bytes(bytes.as_mut_slice());
-
+        getrandom(bytes.as_mut_slice()).expect("RNG failure!");
         Self { bytes }
     }
 

--- a/src/ed25519/seed.rs
+++ b/src/ed25519/seed.rs
@@ -6,11 +6,8 @@ use crate::encoding::Decode;
 use crate::error::Error;
 #[cfg(all(feature = "alloc", feature = "encoding"))]
 use crate::{encoding::Encode, prelude::*};
-#[cfg(feature = "rand_os")]
-use rand_os::{
-    rand_core::{CryptoRng, RngCore},
-    OsRng,
-};
+#[cfg(feature = "getrandom")]
+use getrandom::getrandom;
 #[cfg(feature = "encoding")]
 use subtle_encoding::Encoding;
 use zeroize::Zeroize;
@@ -33,20 +30,10 @@ impl Seed {
 
     /// Generate a new Ed25519 seed using the operating system's
     /// cryptographically secure random number generator
-    #[cfg(feature = "rand_os")]
+    #[cfg(feature = "getrandom")]
     pub fn generate() -> Self {
-        let mut csprng = OsRng::new().expect("RNG initialization failure!");
-        Self::generate_from_rng::<OsRng>(&mut csprng)
-    }
-
-    /// Generate a new Ed25519 seed using the provided random number generator
-    #[cfg(feature = "rand_os")]
-    pub fn generate_from_rng<R>(csprng: &mut R) -> Self
-    where
-        R: CryptoRng + RngCore,
-    {
         let mut bytes = [0u8; SEED_SIZE];
-        csprng.fill_bytes(&mut bytes[..]);
+        getrandom(&mut bytes[..]).expect("RNG failure!");
         Self::new(bytes)
     }
 


### PR DESCRIPTION
`rand_os` is now a wrapper for `getrandom` which includes some fallback implementations which are somewhat questionable.

Issues are being worked on upstream, but in the meantime the creators of `rand_os` spun the "thinnest possible wrapper to the OS's CSPRNG" functionality into `getrandom`.