### PR TITLE
Update to signature v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ autobenches = false
 circle-ci = { repository = "tendermint/signatory", branch = "develop" }
 
 [dependencies]
-generic-array = { version = "0.12", optional = true }
+generic-array = { version = "0.12", optional = true, default-features = false }
 getrandom = { version = "0.1", optional = true, default-features = false }
-signature = "0.1"
-zeroize = { version = "0.9", optional = true }
+sha2 = { version = "0.8", optional = true, default-features = false }
+signature = { version = "0.2", default-features = false }
+zeroize = { version = "0.9", optional = true, default-features = false }
 
 [dependencies.subtle-encoding]
 version = "0.3.6"
@@ -35,7 +36,7 @@ ecdsa = ["generic-array", "zeroize"]
 ed25519 = ["zeroize"]
 encoding = ["subtle-encoding", "zeroize"]
 pkcs8 = ["encoding"]
-std = ["alloc", "subtle-encoding/std"]
+std = ["alloc", "signature/std", "subtle-encoding/std"]
 test-vectors = []
 
 [workspace]
@@ -65,7 +66,4 @@ debug-assertions = false
 codegen-units = 1
 
 [package.metadata.docs.rs]
-features = ["digest", "ecdsa", "ed25519", "pkcs8", "sha2"]
-
-[patch.crates-io]
-signature = { git = "https://github.com/RustCrypto/signatures", rev = "a94234e" }
+all-features = true

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Apache License (Version 2.0), at your option.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 
+[//]: # (badges)
+
 [crate-image]: https://img.shields.io/crates/v/signatory.svg
 [crate-link]: https://crates.io/crates/signatory
 [docs-image]: https://docs.rs/signatory/badge.svg
@@ -72,6 +74,9 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
 [build-image]: https://circleci.com/gh/tendermint/signatory.svg?style=shield
 [build-link]: https://circleci.com/gh/tendermint/signatory
+
+[//]: # (general links)
+
 [FIPS 186‑4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 [RFC 8032]: https://tools.ietf.org/html/rfc8032
 [ed25519‑dalek]: https://github.com/dalek-cryptography/ed25519-dalek

--- a/signatory-ledger-tm/Cargo.toml
+++ b/signatory-ledger-tm/Cargo.toml
@@ -16,7 +16,7 @@ circle-ci = { repository = "tendermint/signatory" }
 
 [dependencies]
 lazy_static = "1"
-ledger-tendermint = "0.3.1"
+ledger-tendermint = "0.4"
 libc = "0.2"
 
 [dependencies.signatory]

--- a/signatory-ledger-tm/src/lib.rs
+++ b/signatory-ledger-tm/src/lib.rs
@@ -7,7 +7,7 @@
     html_root_url = "https://docs.rs/signatory-ledger-tm/0.11.0"
 )]
 
-use ledger_tendermint::TendermintValidatorApp;
+use ledger_tendermint::ledgertm::TendermintValidatorApp;
 use signatory::{
     ed25519::{PublicKey, Signature},
     Error, PublicKeyed, Signer,

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -16,11 +16,11 @@ circle-ci = { repository = "tendermint/signatory" }
 
 [dependencies]
 secp256k1 = "0.13"
-sha2 = { version =  "0.8", default-features = false }
+signature = { version = "0.2", features = ["signature_derive"] }
 
 [dependencies.signatory]
 version = "0.11"
-features = ["digest", "ecdsa", "test-vectors"]
+features = ["digest", "ecdsa", "sha2", "test-vectors"]
 path = ".."
 
 [dev-dependencies]

--- a/signatory-secp256k1/benches/ecdsa.rs
+++ b/signatory-secp256k1/benches/ecdsa.rs
@@ -15,7 +15,7 @@ use signatory::{
     },
     generic_array::GenericArray,
     test_vector::TestVector,
-    DigestSigner, DigestVerifier, Signature,
+    Signature, Signer, Verifier,
 };
 use signatory_secp256k1::{EcdsaSigner, EcdsaVerifier};
 
@@ -27,7 +27,7 @@ fn sign_ecdsa(c: &mut Criterion) {
 
     c.bench_function("secp256k1: ECDSA signer", move |b| {
         b.iter(|| {
-            let _: FixedSignature = signer.sign_msg_digest(TEST_VECTOR.msg);
+            let _: FixedSignature = signer.sign(TEST_VECTOR.msg);
         })
     });
 }
@@ -40,9 +40,7 @@ fn verify_ecdsa(c: &mut Criterion) {
 
     c.bench_function("secp256k1: ECDSA verifier", move |b| {
         b.iter(|| {
-            verifier
-                .verify_msg_digest(TEST_VECTOR.msg, &signature)
-                .unwrap();
+            verifier.verify(TEST_VECTOR.msg, &signature).unwrap();
         })
     });
 }

--- a/src/ecdsa/curve.rs
+++ b/src/ecdsa/curve.rs
@@ -1,5 +1,9 @@
 //! Elliptic Curves: Weierstrass form - for use with ECDSA.
 
+#[cfg(all(feature = "digest", feature = "sha2"))]
+#[macro_use]
+mod macros;
+
 pub mod nistp256;
 pub mod nistp384;
 pub mod point;

--- a/src/ecdsa/curve/macros.rs
+++ b/src/ecdsa/curve/macros.rs
@@ -1,0 +1,13 @@
+//! Macros used for defining elliptic curve types
+
+macro_rules! impl_digest_signature {
+    ($digest:ident, $sig_asn1:ident, $sig_fixed:ident) => {
+        impl $crate::DigestSignature for $sig_asn1 {
+            type Digest = $digest;
+        }
+
+        impl $crate::DigestSignature for $sig_fixed {
+            type Digest = $digest;
+        }
+    };
+}

--- a/src/ecdsa/curve/nistp256.rs
+++ b/src/ecdsa/curve/nistp256.rs
@@ -12,6 +12,8 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::SHA256_FIXED_SIZE_TEST_VECTORS;
 use super::{WeierstrassCurve, WeierstrassCurveKind};
+#[cfg(all(feature = "digest", feature = "sha2"))]
+use crate::sha2::Sha256;
 use generic_array::typenum::{U32, U33, U64, U65, U73};
 
 /// The NIST P-256 elliptic curve: y² = x³ - 3x + b over a ~256-bit prime field
@@ -65,3 +67,6 @@ pub type Asn1Signature = crate::ecdsa::Asn1Signature<NistP256>;
 
 /// Compact, fixed-sized secp256k1 ECDSA signature
 pub type FixedSignature = crate::ecdsa::FixedSignature<NistP256>;
+
+#[cfg(all(feature = "digest", feature = "sha2"))]
+impl_digest_signature!(Sha256, Asn1Signature, FixedSignature);

--- a/src/ecdsa/curve/nistp384.rs
+++ b/src/ecdsa/curve/nistp384.rs
@@ -12,6 +12,8 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::SHA384_FIXED_SIZE_TEST_VECTORS;
 use super::{WeierstrassCurve, WeierstrassCurveKind};
+#[cfg(all(feature = "digest", feature = "sha2"))]
+use crate::sha2::Sha384;
 use generic_array::typenum::{U105, U48, U49, U96, U97};
 
 /// The NIST P-384 elliptic curve: y² = x³ - 3x + b over a ~384-bit prime field
@@ -66,3 +68,6 @@ pub type Asn1Signature = crate::ecdsa::Asn1Signature<NistP384>;
 
 /// Compact, fixed-sized secp384k1 ECDSA signature
 pub type FixedSignature = crate::ecdsa::FixedSignature<NistP384>;
+
+#[cfg(all(feature = "digest", feature = "sha2"))]
+impl_digest_signature!(Sha384, Asn1Signature, FixedSignature);

--- a/src/ecdsa/curve/secp256k1.rs
+++ b/src/ecdsa/curve/secp256k1.rs
@@ -11,6 +11,8 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::SHA256_FIXED_SIZE_TEST_VECTORS;
 use super::{WeierstrassCurve, WeierstrassCurveKind};
+#[cfg(all(feature = "digest", feature = "sha2"))]
+use crate::sha2::Sha256;
 use generic_array::typenum::{U32, U33, U64, U65, U73};
 
 /// The secp256k1 elliptic curve: y² = x³ + 7 over a ~256-bit prime field
@@ -55,3 +57,6 @@ pub type Asn1Signature = crate::ecdsa::Asn1Signature<Secp256k1>;
 
 /// Compact, fixed-sized secp256k1 ECDSA signature
 pub type FixedSignature = crate::ecdsa::FixedSignature<Secp256k1>;
+
+#[cfg(all(feature = "digest", feature = "sha2"))]
+impl_digest_signature!(Sha256, Asn1Signature, FixedSignature);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@
 //! [yubihsm::ecdsa::Signer]: https://docs.rs/yubihsm/latest/yubihsm/ecdsa/struct.Signer.html
 //! [yubihsm::ed25519::Signer]: https://docs.rs/yubihsm/latest/yubihsm/ed25519/struct.Signer.html
 //! [Signer]: https://docs.rs/signatory/latest/signatory/trait.Signer.html
+//! [DigestSigner]: https://docs.rs/signatory/latest/signatory/trait.DigestSigner.html
 //! [Verifier]: https://docs.rs/signatory/latest/signatory/trait.Verifier.html
 //! [DigestVerifier]: https://docs.rs/signatory/latest/signatory/trait.DigestVerifier.html
-//! [turbofish]: https://turbo.fish/
 
 #![no_std]
 #![deny(
@@ -104,6 +104,8 @@ pub use crate::public_key::{PublicKey, PublicKeyed};
 pub use digest;
 #[cfg(feature = "generic-array")]
 pub use generic_array;
+#[cfg(feature = "sha2")]
+pub use sha2;
 pub use signature;
 
 // TODO(tarcieri): remove this and require downstream consumers to use `signatory::signature`


### PR DESCRIPTION
Uses the newly released version of the `signature` crate to complete the work that was started in #160.

This both uses a released version of the `signature` crate with a compatible API, and implements `signatory-secp256k1` using the new custom derive support for `Signer` and `Verifier`.

It also adds support for the `DigestSignature` feature of the upstream crate which associates the default hash function to use for a particular signature type as an associated type.