### PR TITLE
v0.12.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,15 @@
+## [0.12.0] (2019-06-07)
+
+- Use the `signature` crate ([#160], [#161])
+
 ## [0.11.5] (2019-06-04)
 
-- Upgrade to zeroize 0.9 ([#158])
+- Upgrade to `zeroize` 0.9 ([#158])
 
 ## [0.11.4] (2019-05-20)
 
 - Support stable `alloc` API ([#154])
-- Upgrade to zeroize 0.8 ([#153])
+- Upgrade to `zeroize` 0.8 ([#153])
 
 ## [0.11.3] (2019-03-13)
 
@@ -33,7 +37,7 @@
 
 ## [0.10.1] (2018-11-27)
 
-- Upgrade to subtle-encoding v0.3.0 (#132)
+- Upgrade to `subtle-encoding` v0.3.0 (#132)
 
 ## [0.10.0] (2018-10-16)
 
@@ -46,7 +50,7 @@
 
 ## [0.9.3] (2018-10-09)
 
-- Upgrade to subtle-encoding v0.2 (#123)
+- Upgrade to `subtle-encoding` v0.2 (#123)
 - Fix unused import on Windows (closes #121) (#122)
 
 ## [0.9.2] (2018-10-08)
@@ -81,12 +85,12 @@
 
 ## [0.8.0] (2018-08-19)
 
-- Extract 'from_pkcs8' into a trait (#67)
+- Extract `from_pkcs8` into a trait (#67)
 - signatory-yubihsm: Make ecdsa and ed25519 modules public (#65)
 
 ## [0.7.0] (2018-08-19)
 
-- Factor providers into their own 'signatory-*' crates (#63)
+- Factor providers into their own `signatory-*` crates (#63)
 - Unify ECDSA traits across DER and fixed-sized signatures (#62)
 - ECDSA DER signature parsing and serialization (#61)
 
@@ -99,19 +103,19 @@
 - Factor ECDSA PublicKey into compressed/uncompressed curve points (#56)
 - ECDSA support for `yubihsm-provider` (#55)
 - Upgrade to `yubihsm` crate 0.14 (#54)
-- Add Rustdoc logo (#53)
-- Audit project for security vulnerabilities with cargo-audit (#52)
-- Update to ed25519-dalek 0.8 (#51)
+- Add rustdoc logo (#53)
+- Audit project for security vulnerabilities with `cargo-audit` (#52)
+- Update to `ed25519-dalek` 0.8 (#51)
 - Add ECDSA NIST P-256 support with *ring* provider (#49)
 - Factor ECDSA traits apart into separate traits per method (#46)
-- Upgrade to sodiumoxide 0.1 (#40)
+- Upgrade to `sodiumoxide` 0.1 (#40)
 - Add `ed25519::Seed::from_keypair` method (#38)
 - No default features (#37)
 - Add `ed25519::Seed` type (#35)
 
 ## [0.5.2] (2018-05-19)
 
-- Update to yubihsm-rs 0.9 (#32)
+- Update to `yubihsm-rs` 0.9 (#32)
 - Fix benchmarks (#30)
 
 ## [0.5.1] (2018-04-13)
@@ -120,30 +124,30 @@
 
 ## [0.5.0] (2018-04-12)
 
-- Upgrade to yubihsm-rs 0.8 (#27)
+- Upgrade to `yubihsm-rs` 0.8 (#27)
 - ECDSA verification support (#26)
 - ECDSA support with secp256k1 provider (#25)
 - Ed25519 FromSeed trait and miscellaneous cleanups (#24)
-- Remove unnecessary direct dependency on curve25519-dalek (#12)
+- Remove unnecessary direct dependency on `curve25519-dalek` (#12)
 
 ## [0.4.1] (2018-04-05)
 
-- Add more bounds to the Verifier trait (#20)
+- Add more bounds to the `Verifier` trait (#20)
 
 ## [0.4.0] (2018-04-05)
 
-- Add an "ed25519" module to all providers (#19)
-- sodiumoxide provider for Ed25519 (#18)
+- Add an `ed25519` module to all providers (#19)
+- `sodiumoxide` provider for Ed25519 (#18)
 - *ring* Ed25519 provider (#17)
-- ed25519::Verifier trait (#16)
+- `ed25519::Verifier` trait (#16)
 
 ## [0.3.2] (2018-03-31)
 
-- Upgrade ed25519-dalek to 0.6.2 (#15)
+- Upgrade `ed25519-dalek` to 0.6.2 (#15)
 
 ## [0.3.1] (2018-03-27)
 
-- Update to yubihsm-rs 0.7 (#14)
+- Update to `yubihsm-rs` 0.7 (#14)
 
 ## [0.3.0] (2018-03-20)
 
@@ -157,6 +161,9 @@
 
 - Initial release
 
+[0.12.0]: https://github.com/tendermint/signatory/pull/162
+[#161]: https://github.com/tendermint/signatory/pull/161
+[#160]: https://github.com/tendermint/signatory/pull/160
 [0.11.5]: https://github.com/tendermint/signatory/pull/159
 [#158]: https://github.com/tendermint/signatory/pull/158
 [0.11.4]: https://github.com/tendermint/signatory/pull/155

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.11.5" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curve digital signature algorithms, namely ECDSA (described in [FIPS 186‑4])
 and Ed25519 (described in [RFC 8032]).
 
 Signatory provides a thread-safe and object-safe API and implements providers
-for many popular Rust crates, including [ed25519‑dalek], [secp256k1], [ring],
+for many popular Rust crates, including [ed25519‑dalek], [*ring*], [secp256k1], 
 and [sodiumoxide].
 
 [Documentation][docs-link]
@@ -36,7 +36,7 @@ own respective crates (except for the [yubihsm] provider, which is included
 
 | Provider Crate        | Backend Crate  | Type | P‑256  | P‑384  | secp256k1  |
 | --------------------- | -------------- | ---- | ------ | ------ | ---------- |
-| [signatory‑ring]      | [ring]         | Soft | ✅     | ✅     | ⛔         |
+| [signatory‑ring]      | [*ring*]       | Soft | ✅     | ✅     | ⛔         |
 | [signatory‑secp256k1] | [secp256k1]    | Soft | ⛔     | ⛔     | ✅         |
 | [yubihsm]             | [yubihsm]      | Hard | ✅     | ✅     | ✅         |
 
@@ -45,7 +45,7 @@ own respective crates (except for the [yubihsm] provider, which is included
 | Provider Crate          | Backend Crate   | Type | Signing | Verification |
 | ----------------------- | --------------- | ---- | ------- | ------------ |
 | [signatory‑dalek]       | [ed25519‑dalek] | Soft | 51 k/s  | 18 k/s       |
-| [signatory‑ring]        | [ring]          | Soft | 47 k/s  | 16 k/s       |
+| [signatory‑ring]        | [*ring*]        | Soft | 47 k/s  | 16 k/s       |
 | [signatory‑sodiumoxide] | [sodiumoxide]   | Soft | 38 k/s  | 15 k/s       |
 | [yubihsm]               | [yubihsm]       | Hard | ~8/s    | N/A          |
 
@@ -80,7 +80,7 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 [FIPS 186‑4]: https://csrc.nist.gov/publications/detail/fips/186/4/final
 [RFC 8032]: https://tools.ietf.org/html/rfc8032
 [ed25519‑dalek]: https://github.com/dalek-cryptography/ed25519-dalek
-[ring]: https://github.com/briansmith/ring
+[*ring*]: https://github.com/briansmith/ring
 [secp256k1]: https://github.com/rust-bitcoin/rust-secp256k1/
 [sodiumoxide]: https://github.com/dnaq/sodiumoxide
 [yubihsm]: https://github.com/tendermint/yubihsm-rs

--- a/signatory-dalek/Cargo.toml
+++ b/signatory-dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-dalek"
 description = "Signatory Ed25519 provider for ed25519-dalek"
-version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -20,7 +20,7 @@ ed25519-dalek = { version = "1.0.0-pre.1", default-features = false }
 sha2 = { version =  "0.8", default-features = false }
 
 [dependencies.signatory]
-version = "0.11"
+version = "0.12"
 default-features = false
 features = ["digest", "ed25519", "generic-array", "test-vectors"]
 path = ".."

--- a/signatory-dalek/src/lib.rs
+++ b/signatory-dalek/src/lib.rs
@@ -17,7 +17,7 @@
 )]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-dalek/0.11.0"
+    html_root_url = "https://docs.rs/signatory-dalek/0.12.0"
 )]
 
 #[cfg(test)]

--- a/signatory-ledger-tm/Cargo.toml
+++ b/signatory-ledger-tm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ledger-tm"
 description = "Signatory provider for Ledger Tendermint Validator app"
-version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -20,7 +20,7 @@ ledger-tendermint = "0.4"
 libc = "0.2"
 
 [dependencies.signatory]
-version = "0.11"
+version = "0.12"
 features = ["digest", "ed25519", "generic-array", "test-vectors"]
 path = ".."
 

--- a/signatory-ledger-tm/src/lib.rs
+++ b/signatory-ledger-tm/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ledger-tm/0.11.0"
+    html_root_url = "https://docs.rs/signatory-ledger-tm/0.12.0"
 )]
 
 use ledger_tendermint::ledgertm::TendermintValidatorApp;

--- a/signatory-ring/Cargo.toml
+++ b/signatory-ring/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
-version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -19,7 +19,7 @@ ring = "0.14"
 untrusted = "0.6"
 
 [dependencies.signatory]
-version = "0.11"
+version = "0.12"
 default-features = false
 features = ["pkcs8", "test-vectors"]
 path = ".."

--- a/signatory-ring/src/lib.rs
+++ b/signatory-ring/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ring/0.11.0"
+    html_root_url = "https://docs.rs/signatory-ring/0.12.0"
 )]
 
 #[cfg(test)]

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
-version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -19,7 +19,7 @@ secp256k1 = "0.13"
 signature = { version = "0.2", features = ["signature_derive"] }
 
 [dependencies.signatory]
-version = "0.11"
+version = "0.12"
 features = ["digest", "ecdsa", "sha2", "test-vectors"]
 path = ".."
 

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-secp256k1/0.11.0"
+    html_root_url = "https://docs.rs/signatory-secp256k1/0.12.0"
 )]
 
 use secp256k1::{self, Secp256k1, SignOnly, VerifyOnly};

--- a/signatory-sodiumoxide/Cargo.toml
+++ b/signatory-sodiumoxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
-version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -18,7 +18,7 @@ circle-ci = { repository = "tendermint/signatory" }
 sodiumoxide = "0.2"
 
 [dependencies.signatory]
-version = "0.11"
+version = "0.12"
 features = ["ed25519", "test-vectors"]
 path = ".."
 

--- a/signatory-sodiumoxide/src/lib.rs
+++ b/signatory-sodiumoxide/src/lib.rs
@@ -5,7 +5,7 @@
 #![deny(unsafe_code, unused_import_braces, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.11.0"
+    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.12.0"
 )]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 )]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.11.5"
+    html_root_url = "https://docs.rs/signatory/0.12.0"
 )]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]


### PR DESCRIPTION
- Use the `signature` crate (#160, #161)