### PR TITLE
Upgrade to `signature` crate v0.3, `ed25519` crate v0.2; MSRV 1.36+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,13 @@ jobs:
     - restore_cache:
         key: cache-2019-06-05-v0 # bump save_cache key below too
     - run:
+        name: Install Rust 1.36.0 # TODO: update Rust in the upstream Docker image
+        command: |
+          rustup toolchain install 1.36.0
+          rustup default 1.36.0
+          rustup component add rustfmt
+          rustup component add clippy
+    - run:
         name: rustfmt
         command: |
           cargo fmt --version
@@ -17,7 +24,7 @@ jobs:
         name: clippy
         command: |
           cargo clippy --version
-          cargo clippy --all
+          cargo clippy --all --exclude signatory-sodiumoxide # sodiumoxide isn't clippy-friendly
     - run:
         name: build (--no-default-features)
         command: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ circle-ci = { repository = "tendermint/signatory", branch = "develop" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-ed25519 = { version = "0.1", optional = true, default-features = false }
+ed25519 = { version = "0.2", optional = true, default-features = false }
 generic-array = { version = "0.12", optional = true, default-features = false }
 getrandom = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.8", optional = true, default-features = false }
-signature = { version = "0.2", default-features = false }
-zeroize = { version = "0.9", default-features = false }
+signature = { version = "0.3", default-features = false }
+zeroize = { version = "1.0.0-pre", default-features = false }
 
 [dependencies.subtle-encoding]
-version = "0.3.6"
+version = "0.4"
 optional = true
 default-features = false
 features = ["base64", "hex"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# ![Signatory](https://www.iqlusion.io/img/github/tendermint/signatory/signatory.svg)
+# ![Signatory][logo]
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
-![Rust 1.35+][rustc-image]
+![MSRV][rustc-image]
 [![Build Status][build-image]][build-link]
 
 A pure Rust multi-provider digital signature library with support for elliptic
@@ -24,7 +24,7 @@ specific providers selected at runtime.
 
 ## Requirements
 
-All Signatory providers require Rust 1.35+.
+All Signatory providers require Rust **1.36+**
 
 ## Provider Support
 
@@ -66,12 +66,13 @@ See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 
 [//]: # (badges)
 
+[logo]: https://www.iqlusion.io/img/github/tendermint/signatory/signatory.svg
 [crate-image]: https://img.shields.io/crates/v/signatory.svg
 [crate-link]: https://crates.io/crates/signatory
 [docs-image]: https://docs.rs/signatory/badge.svg
 [docs-link]: https://docs.rs/signatory/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.35+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [build-image]: https://circleci.com/gh/tendermint/signatory.svg?style=shield
 [build-link]: https://circleci.com/gh/tendermint/signatory
 

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 secp256k1 = "0.15"
-signature = { version = "0.2", features = ["signature_derive"] }
+signature = { version = "0.3", features = ["signature_derive"] }
 
 [dependencies.signatory]
 version = "0.13"

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -17,6 +17,7 @@ use signatory::{
 
 /// ECDSA signature provider for the secp256k1 crate
 #[derive(Signer)]
+#[digest(Sha256)]
 pub struct EcdsaSigner {
     /// ECDSA secret key
     secret_key: secp256k1::SecretKey,
@@ -71,6 +72,7 @@ impl EcdsaSigner {
 
 /// ECDSA verifier provider for the secp256k1 crate
 #[derive(Clone, Debug, Eq, PartialEq, Verifier)]
+#[digest(Sha256)]
 pub struct EcdsaVerifier {
     /// ECDSA public key
     public_key: secp256k1::PublicKey,

--- a/src/ecdsa/curve/nistp256.rs
+++ b/src/ecdsa/curve/nistp256.rs
@@ -12,8 +12,6 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::SHA256_FIXED_SIZE_TEST_VECTORS;
 use super::{WeierstrassCurve, WeierstrassCurveKind};
-#[cfg(all(feature = "digest", feature = "sha2"))]
-use crate::sha2::Sha256;
 use generic_array::typenum::{U32, U33, U64, U65, U73};
 
 /// The NIST P-256 elliptic curve: y² = x³ - 3x + b over a ~256-bit prime field
@@ -67,13 +65,3 @@ pub type Asn1Signature = crate::ecdsa::Asn1Signature<NistP256>;
 
 /// Compact, fixed-sized secp256k1 ECDSA signature
 pub type FixedSignature = crate::ecdsa::FixedSignature<NistP256>;
-
-#[cfg(all(feature = "digest", feature = "sha2"))]
-impl signature::DigestSignature for Asn1Signature {
-    type Digest = Sha256;
-}
-
-#[cfg(all(feature = "digest", feature = "sha2"))]
-impl signature::DigestSignature for FixedSignature {
-    type Digest = Sha256;
-}

--- a/src/ecdsa/curve/nistp384.rs
+++ b/src/ecdsa/curve/nistp384.rs
@@ -12,8 +12,6 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::SHA384_FIXED_SIZE_TEST_VECTORS;
 use super::{WeierstrassCurve, WeierstrassCurveKind};
-#[cfg(all(feature = "digest", feature = "sha2"))]
-use crate::sha2::Sha384;
 use generic_array::typenum::{U105, U48, U49, U96, U97};
 
 /// The NIST P-384 elliptic curve: y² = x³ - 3x + b over a ~384-bit prime field
@@ -68,13 +66,3 @@ pub type Asn1Signature = crate::ecdsa::Asn1Signature<NistP384>;
 
 /// Compact, fixed-sized secp384k1 ECDSA signature
 pub type FixedSignature = crate::ecdsa::FixedSignature<NistP384>;
-
-#[cfg(all(feature = "digest", feature = "sha2"))]
-impl signature::DigestSignature for Asn1Signature {
-    type Digest = Sha384;
-}
-
-#[cfg(all(feature = "digest", feature = "sha2"))]
-impl signature::DigestSignature for FixedSignature {
-    type Digest = Sha384;
-}

--- a/src/ecdsa/curve/secp256k1.rs
+++ b/src/ecdsa/curve/secp256k1.rs
@@ -11,8 +11,6 @@ mod test_vectors;
 #[cfg(feature = "test-vectors")]
 pub use self::test_vectors::SHA256_FIXED_SIZE_TEST_VECTORS;
 use super::{WeierstrassCurve, WeierstrassCurveKind};
-#[cfg(all(feature = "digest", feature = "sha2"))]
-use crate::sha2::Sha256;
 use generic_array::typenum::{U32, U33, U64, U65, U73};
 
 /// The secp256k1 elliptic curve: y² = x³ + 7 over a ~256-bit prime field
@@ -57,13 +55,3 @@ pub type Asn1Signature = crate::ecdsa::Asn1Signature<Secp256k1>;
 
 /// Compact, fixed-sized secp256k1 ECDSA signature
 pub type FixedSignature = crate::ecdsa::FixedSignature<Secp256k1>;
-
-#[cfg(all(feature = "digest", feature = "sha2"))]
-impl signature::DigestSignature for Asn1Signature {
-    type Digest = Sha256;
-}
-
-#[cfg(all(feature = "digest", feature = "sha2"))]
-impl signature::DigestSignature for FixedSignature {
-    type Digest = Sha256;
-}


### PR DESCRIPTION
Updates to the latest release of the `signature` crate, which directly uses the `alloc` library and therefore requires Rust 1.36+.