### PR TITLE
v0.14.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.14.0] (2019-10-10)
+
+- Always use the `alloc` crate for `String`/`Vec` ([#170])
+- Upgrade to `signature` crate v0.3, `ed25519` crate v0.2; MSRV 1.36+ ([#169])
+
 ## [0.13.0] (2019-08-11)
 
 - Update ring to v0.16; secp256k1 to v0.15 ([#167])
@@ -167,6 +172,9 @@
 
 - Initial release
 
+[0.14.0]: https://github.com/tendermint/signatory/pull/171
+[#169]: https://github.com/tendermint/signatory/pull/169
+[#168]: https://github.com/tendermint/signatory/pull/168
 [0.13.0]: https://github.com/tendermint/signatory/pull/168
 [#167]: https://github.com/tendermint/signatory/pull/167
 [#166]: https://github.com/tendermint/signatory/pull/166

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory"
 description = "Multi-provider elliptic curve digital signature library with ECDSA and Ed25519 support"
-version     = "0.13.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.14.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"

--- a/signatory-dalek/Cargo.toml
+++ b/signatory-dalek/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-dalek"
 description = "Signatory Ed25519 provider for ed25519-dalek"
-version     = "0.13.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.14.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -21,7 +21,7 @@ ed25519-dalek = { version = "1.0.0-pre.1", default-features = false }
 sha2 = { version =  "0.8", default-features = false }
 
 [dependencies.signatory]
-version = "0.13"
+version = "0.14"
 default-features = false
 features = ["digest", "ed25519", "generic-array", "test-vectors"]
 path = ".."

--- a/signatory-dalek/src/lib.rs
+++ b/signatory-dalek/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-dalek/0.13.0"
+    html_root_url = "https://docs.rs/signatory-dalek/0.14.0"
 )]
 
 #[cfg(test)]

--- a/signatory-ledger-tm/Cargo.toml
+++ b/signatory-ledger-tm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ledger-tm"
 description = "Signatory provider for Ledger Tendermint Validator app"
-version     = "0.13.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.14.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["ZondaX GmbH <info@zondax.ch>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -20,7 +20,7 @@ lazy_static = "1"
 ledger-tendermint = "0.4"
 
 [dependencies.signatory]
-version = "0.13"
+version = "0.14"
 features = ["digest", "ed25519", "generic-array", "test-vectors"]
 path = ".."
 

--- a/signatory-ledger-tm/src/lib.rs
+++ b/signatory-ledger-tm/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ledger-tm/0.13.0"
+    html_root_url = "https://docs.rs/signatory-ledger-tm/0.14.0"
 )]
 
 use ledger_tendermint::ledgertm::TendermintValidatorApp;

--- a/signatory-ring/Cargo.toml
+++ b/signatory-ring/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-ring"
 description = "Signatory ECDSA (NIST P-256) and Ed25519 provider for *ring*"
-version     = "0.13.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.14.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -19,7 +19,7 @@ maintenance = { status = "passively-maintained" }
 ring = { version = "0.16", default-features = false }
 
 [dependencies.signatory]
-version = "0.13"
+version = "0.14"
 default-features = false
 features = ["pkcs8", "test-vectors"]
 path = ".."

--- a/signatory-ring/src/lib.rs
+++ b/signatory-ring/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-ring/0.13.0"
+    html_root_url = "https://docs.rs/signatory-ring/0.14.0"
 )]
 
 #[cfg(test)]

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-secp256k1"
 description = "Signatory ECDSA provider for secp256k1-rs"
-version     = "0.13.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.14.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -20,7 +20,7 @@ secp256k1 = "0.15"
 signature = { version = "0.3", features = ["signature_derive"] }
 
 [dependencies.signatory]
-version = "0.13"
+version = "0.14"
 features = ["digest", "ecdsa", "sha2", "test-vectors"]
 path = ".."
 

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-secp256k1/0.13.0"
+    html_root_url = "https://docs.rs/signatory-secp256k1/0.14.0"
 )]
 
 use secp256k1::{self, Secp256k1, SignOnly, VerifyOnly};

--- a/signatory-sodiumoxide/Cargo.toml
+++ b/signatory-sodiumoxide/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "signatory-sodiumoxide"
 description = "Signatory Ed25519 provider for sodiumoxide"
-version     = "0.13.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.14.0" # Also update html_root_url in lib.rs when bumping this
 license     = "Apache-2.0 OR MIT"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/tendermint/signatory"
@@ -19,7 +19,7 @@ maintenance = { status = "passively-maintained" }
 sodiumoxide = "0.2"
 
 [dependencies.signatory]
-version = "0.13"
+version = "0.14"
 features = ["ed25519", "test-vectors"]
 path = ".."
 

--- a/signatory-sodiumoxide/src/lib.rs
+++ b/signatory-sodiumoxide/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.13.0"
+    html_root_url = "https://docs.rs/signatory-sodiumoxide/0.14.0"
 )]
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/signatory/develop/img/signatory-rustacean.png",
-    html_root_url = "https://docs.rs/signatory/0.13.0"
+    html_root_url = "https://docs.rs/signatory/0.14.0"
 )]
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
- Always use the `alloc` crate for `String`/`Vec` (#170)
- Upgrade to `signature` crate v0.3, `ed25519` crate v0.2; MSRV 1.36+ (#169)