### PR TITLE
.circleci: Add back audit step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,11 @@ jobs:
           cargo build --package=signatory-ledger-tm
           # Temporarily Disabling testing until a mockhsm is available
           # cd signatory-ledger-tm && cargo test
+    - run:
+        name: audit
+        command: |
+          cargo audit --version
+          cargo audit
     - save_cache:
         key: cache-2019-06-05-v0 # bump restore_cache key above too
         paths:


### PR DESCRIPTION
Removed because no solution for `sodiumoxide` (and the `cargo-audit` in the Docker image is too old to support the `--ignore` option), but the new version is out now:

https://www.reddit.com/r/rust/comments/dguqt3/vulnerability_in_sodiumoxide_generichashdigesteq/