### PR TITLE
Cargo.toml(s): lock directly to all prerelease crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 ecdsa = { version = "0.3", optional = true }
-ed25519 = { version = "1.0.0-pre.1", optional = true, default-features = false }
+ed25519 = { version = "= 1.0.0-pre.1", optional = true, default-features = false }
 getrandom = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.8", optional = true, default-features = false }
-signature = { version = "1.0.0-pre.1", default-features = false }
+signature = { version = "= 1.0.0-pre.1", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dependencies.subtle-encoding]

--- a/signatory-dalek/Cargo.toml
+++ b/signatory-dalek/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 digest = { version = "0.8", default-features = false }
-ed25519-dalek = { version = "1.0.0-pre.2", default-features = false }
+ed25519-dalek = { version = "= 1.0.0-pre.2", default-features = false }
 sha2 = { version =  "0.8", default-features = false }
 
 [dependencies.signatory]

--- a/signatory-secp256k1/Cargo.toml
+++ b/signatory-secp256k1/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 secp256k1 = "0.15"
-signature = { version = "1.0.0-pre.1", features = ["derive-preview"] }
+signature = { version = "= 1.0.0-pre.1", features = ["derive-preview"] }
 
 [dependencies.signatory]
 version = "0.16"


### PR DESCRIPTION
These crates are effectively semver incompatible from each other and may bring unexpected changes:

https://github.com/interchainio/tendermint-rs/pull/83

This ensures that all crates are locked to a known working prerelease which they were tested with.