### PR TITLE
impl of Keccak256 signer for Ethereum compatible ECDSA signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ getrandom = { version = "0.1", optional = true, default-features = false }
 sha2 = { version = "0.8", optional = true, default-features = false }
 signature = { version = "= 1.0.0-pre.1", default-features = false }
 zeroize = { version = "1", default-features = false }
+sha3 = "0.8"
 
 [dependencies.subtle-encoding]
 version = "0.4"

--- a/signatory-secp256k1/src/lib.rs
+++ b/signatory-secp256k1/src/lib.rs
@@ -67,14 +67,14 @@ impl DigestSigner<Keccak256, FixedSignature> for EcdsaSigner {
     fn try_sign_digest(&self, digest: Keccak256) -> Result<FixedSignature, Error> {
         Ok(
             FixedSignature::from_bytes(&self.raw_sign_digest(digest)?.serialize_compact()[..])
-            .unwrap(),
+                .unwrap(),
         )
     }
 }
 
 impl EcdsaSigner {
     /// Sign a digest and produce a `secp256k1::Signature`
-    fn raw_sign_digest<D:Digest>(&self, digest: D) -> Result<secp256k1::Signature, Error> {
+    fn raw_sign_digest<D: Digest>(&self, digest: D) -> Result<secp256k1::Signature, Error> {
         let msg = secp256k1::Message::from_slice(digest.result().as_slice())
             .map_err(Error::from_source)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,4 +89,5 @@ pub mod test_vector;
 pub use generic_array;
 #[cfg(feature = "sha2")]
 pub use sha2;
+pub use sha3;
 pub use signature;


### PR DESCRIPTION
Add an impl of ECDSA signer that support Ethereum Keccak256 digest signatures﻿
